### PR TITLE
Block variable preview with custom mime types

### DIFF
--- a/src/layouts/explorer/workflow/variables.js
+++ b/src/layouts/explorer/workflow/variables.js
@@ -11,7 +11,7 @@ import DirektivEditor from '../../../components/editor';
 import FlexBox from '../../../components/flexbox';
 import Modal, { ButtonDefinition } from '../../../components/modal';
 import Tabs from '../../../components/tabs';
-import { Config } from '../../../util';
+import { Config, CanPreviewMimeType } from '../../../util';
 import { VariableFilePicker } from '../../settings/variables-panel';
 import { AutoSizer } from 'react-virtualized';
 import HelpIcon from "../../../components/help";
@@ -277,11 +277,19 @@ function Variable(props) {
                     <FlexBox className="col gap" style={{fontSize: "12px", width: "580px", minHeight: "500px"}}>
                         <FlexBox className="gap" style={{flexGrow: 1}}>
                             <FlexBox style={{overflow:"hidden"}}>
+                            {CanPreviewMimeType(mimeType) ?   
                             <AutoSizer>
                                 {({height, width})=>(
                                 <DirektivEditor dlang={lang} width={width} dvalue={val} setDValue={setValue} height={height}/>
                                 )}
                             </AutoSizer>
+                            :
+                            <div style={{width: "100%", display:"flex", justifyContent: "center", alignItems:"center"}}>
+                                <p style={{fontSize:"11pt"}}>
+                                    Cannot preview variable with mime-type: {mimeType}
+                                </p>
+                            </div>
+                            }
                             </FlexBox>
                         </FlexBox>
                         <FlexBox className="gap" style={{flexGrow: 0, flexShrink: 1}}>

--- a/src/layouts/settings/variables-panel/index.js
+++ b/src/layouts/settings/variables-panel/index.js
@@ -5,7 +5,7 @@ import FlexBox from '../../../components/flexbox';
 import Modal, { ButtonDefinition } from '../../../components/modal';
 import AddValueButton from '../../../components/add-button';
 import { useNamespaceVariables } from 'direktiv-react-hooks';
-import { Config } from '../../../util';
+import { Config, CanPreviewMimeType } from '../../../util';
 import DirektivEditor from '../../../components/editor';
 import Button from '../../../components/button';
 import {useDropzone} from 'react-dropzone'
@@ -312,11 +312,19 @@ function Variable(props) {
                     <FlexBox className="col gap" style={{fontSize: "12px", width: "580px", minHeight: "500px"}}>
                         <FlexBox className="gap" style={{flexGrow: 1}}>
                             <FlexBox style={{overflow:"hidden"}}>
+                                {CanPreviewMimeType(mimeType) ?                                
                                 <AutoSizer>
                                     {({height, width})=>(
                                     <DirektivEditor dlang={lang} width={width} dvalue={val} setDValue={setValue} height={height}/>
                                     )}
                                 </AutoSizer>
+                                :
+                                <div style={{width: "100%", display:"flex", justifyContent: "center", alignItems:"center"}}>
+                                    <p style={{fontSize:"11pt"}}>
+                                        Cannot preview variable with mime-type: {mimeType}
+                                    </p>
+                                </div>
+                                }
                             </FlexBox>
                         </FlexBox>
                         <FlexBox className="gap" style={{flexGrow: 0, flexShrink: 1}}>

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -47,3 +47,18 @@ export function GenerateRandomKey(prefix) {
     return prefix + Array(16).fill().map(()=>"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".charAt(Math.random()*62)).join("")
 }
 
+const PreviewableMimeTypes = ["application/json", "application/x-sh", "text/html", "application/yaml", "text/plain"]
+
+export function CanPreviewMimeType(mime) {
+
+  for (let index = 0; index < PreviewableMimeTypes.length; index++) {
+      const pmt = PreviewableMimeTypes[index];
+      if (mime == pmt) {
+          return true
+      }
+  }
+
+  return false
+}
+
+


### PR DESCRIPTION
Signed-off-by: jalfvort <jon.alfaro@direktiv.io>

## Description

Closes https://github.com/direktiv/ui-december-2021/issues/63

## Purpose

- [ ] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Please describe how the proposed changes have been tested, and the outcome of the tests.

## Test Platform Details (if applicable)

**Operating system:** OSX/Windows 10/Ubuntu 20.04/etc.

**CLI version:**

**Hypervisors/Platforms (if applicable):** qemu/hyper-v/google cloud platform/vmware workstation/etc

**Kernel version (if applicable):**

## Checklist

- [ ] Code is commented
- [ ] Unit test coverage encompasses new code
- [ ] Existing unit tests pass with these changes
- [ ] PR is signed
