### PR TITLE
Display target revision on revision page if ref is a tag

### DIFF
--- a/src/layouts/explorer/workflow/revisionTab.js
+++ b/src/layouts/explorer/workflow/revisionTab.js
@@ -23,6 +23,7 @@ function RevisionTab(props) {
     const {searchParams, setSearchParams, revision, setRevision, getWorkflowRevisionData, getWorkflowSankeyMetrics, executeWorkflow, namespace} = props
     const [load, setLoad] = useState(true)
     const [workflow, setWorkflowData] = useState(null)
+    const [revisionID, setRevisionID] = useState(null)
     const [tabBtn, setTabBtn] = useState(searchParams.get('revtab') !== null ? parseInt(searchParams.get('revtab')): 0);
     const [input, setInput] = useState("{\n\t\n}")
 
@@ -41,6 +42,7 @@ function RevisionTab(props) {
             if(load && searchParams.get('revtab') !== null) {
                 let wfdata = await getWorkflowRevisionData(revision)
                 setWorkflowData(atob(wfdata.revision.source))
+                setRevisionID(wfdata.revision.name)
                 setLoad(false)
             }
         }
@@ -70,7 +72,7 @@ function RevisionTab(props) {
                             <BsCodeSquare />
                         </ContentPanelTitleIcon>
                         <div>
-                        {revision}
+                        {revision === revisionID ? revision : `${revision} => ${revisionID}`}
                         </div>
                         <TabbedButtons revision={revision} setSearchParams={setSearchParams} searchParams={searchParams} tabBtn={tabBtn} setTabBtn={setTabBtn} />
                     </ContentPanelTitle>


### PR DESCRIPTION
Signed-off-by: jalfvort <jon.alfaro@direktiv.io>

## Description

Basically just adds the following so you can see what revision a tag is pointing to.
![image](https://user-images.githubusercontent.com/45082495/150034994-363a2a06-3082-45e5-919e-ee46e9f6084b.png)
