### PR TITLE
Closes #213

### DIFF
--- a/src/layouts/explorer/workflow/revisionTab.js
+++ b/src/layouts/explorer/workflow/revisionTab.js
@@ -246,7 +246,6 @@ export function RevisionSelectorTab(props) {
   
     if(!revisions) return null
 
-    console.log(revisions);
     return (
         <FlexBox className="col gap">
             <div>


### PR DESCRIPTION
Closes #213 
The function that updates the revision list after performing a revision deletion was setting the wrong value for a variable, which caused this crash on render.