### PR TITLE
Event listener timestamps updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "d3-sankey-circular": "^0.34.0",
     "dagre": "^0.8.5",
     "dayjs": "^1.10.7",
-    "direktiv-react-hooks": "^0.0.174",
+    "direktiv-react-hooks": "^0.0.183",
     "js-yaml": "^4.1.0",
     "monaco": "^1.201704190613.0",
     "object-hash": "^2.2.0",

--- a/src/layouts/events/index.js
+++ b/src/layouts/events/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Config } from '../../util';
 import {  VscCloud, VscPlay, VscDebugStepInto } from 'react-icons/vsc';
 import Button from '../../components/button';

--- a/src/layouts/events/index.js
+++ b/src/layouts/events/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Config } from '../../util';
 import {  VscCloud, VscPlay, VscDebugStepInto } from 'react-icons/vsc';
 import Button from '../../components/button';
@@ -40,8 +40,7 @@ function EventsPage(props) {
     let {namespace} = props;
 
     // errHistory and errListeners TODO show error if one
-    let {eventHistory, eventListeners, sendEvent, replayEvent} = useEvents(Config.url, true, namespace, localStorage.getItem("apikey"), {listners: [], history: []})
-    console.log(eventListeners)
+    let {eventHistory, eventListeners, sendEvent, replayEvent} = useEvents(Config.url, true, namespace, localStorage.getItem("apikey"), {listeners: [], history: []})
     return(
         <>
             <FlexBox className="gap col" style={{paddingRight: "8px"}}>
@@ -183,7 +182,7 @@ function EventsPage(props) {
                                                         {obj.node.mode}
                                                     </td>
                                                     <td>
-                                                        {dayjs.utc(obj.node.receivedAt).local().format("HH:mm:ss a")}
+                                                        {dayjs.utc(obj.node.updatedAt).local().format("HH:mm:ss a")}
                                                     </td>
                                                     <td className="event-split">
                                                         {obj.node.events.map((obj)=>{

--- a/yarn.lock
+++ b/yarn.lock
@@ -4767,10 +4767,10 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-direktiv-react-hooks@^0.0.174:
-  version "0.0.174"
-  resolved "https://registry.yarnpkg.com/direktiv-react-hooks/-/direktiv-react-hooks-0.0.174.tgz#8ba9ffae4fe31a19e834fcae248d2befbeefe23e"
-  integrity sha512-VcZLLgC2rdRUkcqvc1gF2j2RuuSD40ohfUm3Trw9YTTPx0k4VBOLOQl5gmxvMYRQFzrPKPklKXlu+XMuZfG/kQ==
+direktiv-react-hooks@^0.0.183:
+  version "0.0.183"
+  resolved "https://registry.yarnpkg.com/direktiv-react-hooks/-/direktiv-react-hooks-0.0.183.tgz#24d1b3d42c098a7cc2305e8173ca94b0c8840eb7"
+  integrity sha512-ckBAUxljV1m2n+qNSya79oC6nSZe7zHDmORSHukpmrEW51SRZHl65GFAHawYKpeVo0Gcqz5aBgwJaCz8GYJQHQ==
   dependencies:
     "@types/event-source-polyfill" "^1.0.0"
     cross-fetch "^3.1.4"


### PR DESCRIPTION
Signed-off-by: jalfvort <jon.alfaro@direktiv.io>

## Description

Fixed events table using receivedAt instead of updatedAt  for time row.

## Purpose

- [ ] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Please describe how the proposed changes have been tested, and the outcome of the tests.

## Test Platform Details (if applicable)

**Operating system:** OSX/Windows 10/Ubuntu 20.04/etc.

**CLI version:**

**Hypervisors/Platforms (if applicable):** qemu/hyper-v/google cloud platform/vmware workstation/etc

**Kernel version (if applicable):**

## Checklist

- [ ] Code is commented
- [ ] Unit test coverage encompasses new code
- [ ] Existing unit tests pass with these changes
- [ ] PR is signed
