### PR TITLE
noop template added back as default

### DIFF
--- a/src/layouts/explorer/index.js
+++ b/src/layouts/explorer/index.js
@@ -186,12 +186,12 @@ function ExplorerList(props) {
     const [load, setLoad] = useState(true)
 
     const [orderFieldKey, setOrderFieldKey] = useState(orderFieldKeys[0])
-
-    const [wfData, setWfData] = useState("")
-    const [wfTemplate, setWfTemplate] = useState("")
      
     const [queryParams, setQueryParams] = useState([`first=${PAGE_SIZE}`])
     const {data, err, templates, pageInfo, createNode, deleteNode, renameNode, totalCount } = useNodes(Config.url, true, namespace, path, localStorage.getItem("apikey"), ...queryParams, `order.field=${orderFieldDictionary[orderFieldKey]}`)
+
+    const [wfData, setWfData] = useState(templates["noop"])
+    const [wfTemplate, setWfTemplate] = useState("noop")
 
     function resetQueryParams() {
         setQueryParams([`first=${PAGE_SIZE}`])


### PR DESCRIPTION
Signed-off-by: jalfvort <jon.alfaro@direktiv.io>

## Description

Fixes: https://github.com/direktiv/direktiv-ui/issues/251

## Purpose

- [ ] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Please describe how the proposed changes have been tested, and the outcome of the tests.

## Test Platform Details (if applicable)

**Operating system:** OSX/Windows 10/Ubuntu 20.04/etc.

**CLI version:**

**Hypervisors/Platforms (if applicable):** qemu/hyper-v/google cloud platform/vmware workstation/etc

**Kernel version (if applicable):**

## Checklist

- [ ] Code is commented
- [ ] Unit test coverage encompasses new code
- [ ] Existing unit tests pass with these changes
- [ ] PR is signed
