### PR TITLE
added item count for explorer, events, instances

### DIFF
--- a/src/layouts/events/index.js
+++ b/src/layouts/events/index.js
@@ -36,7 +36,7 @@ function EventsPageWrapper(props) {
 
 export default EventsPageWrapper;
 
-const PAGE_SIZE = 5;
+const PAGE_SIZE = 8;
 
 function EventsPage(props) {
 

--- a/src/layouts/explorer/index.js
+++ b/src/layouts/explorer/index.js
@@ -23,7 +23,7 @@ import { AutoSizer } from 'react-virtualized';
 import Pagination from '../../components/pagination';
 import Alert from '../../components/alert';
 
-const PAGE_SIZE = 5
+const PAGE_SIZE = 10
 const apiHelps = (namespace) => {
     let url = window.location.origin
     return(
@@ -446,7 +446,7 @@ function ExplorerList(props) {
                     </FlexBox>
             </ContentPanelBody>
             <FlexBox>
-                { !!totalCount && <Pagination pageInfo={pageInfo} updatePage={updatePage} total={totalCount}/>}
+                { !!totalCount && <Pagination pageSize={PAGE_SIZE} pageInfo={pageInfo} updatePage={updatePage} total={totalCount}/>}
             </FlexBox>
         </ContentPanel>
     </Loader>

--- a/src/layouts/instances/index.js
+++ b/src/layouts/instances/index.js
@@ -15,7 +15,7 @@ import utc from "dayjs/plugin/utc"
 import { useNavigate } from 'react-router-dom';
 import Loader from '../../components/loader';
 
-const PAGE_SIZE = 5
+const PAGE_SIZE = 10
 
 dayjs.extend(utc)
 dayjs.extend(relativeTime);
@@ -119,7 +119,7 @@ function InstancesTable(props) {
         </ContentPanelBody>
     </ContentPanel>
     <FlexBox>
-        {!!totalCount && <Pagination pageInfo={pageInfo} updatePage={updatePage} total={totalCount}/>}
+        {!!totalCount && <Pagination pageSize={PAGE_SIZE} pageInfo={pageInfo} updatePage={updatePage} total={totalCount}/>}
     </FlexBox>
     </Loader>
         

--- a/src/layouts/monitoring/index.js
+++ b/src/layouts/monitoring/index.js
@@ -208,7 +208,7 @@ function MonitoringPage(props) {
 
 function FailedExecutions(props) {
     const {namespace} = props
-    const [qParams] = useState(["first=10", "filter.field=STATUS", "filter-type=MATCH", "filter.val=failed"])
+    const [qParams] = useState(["first=5", "filter.field=STATUS", "filter-type=MATCH", "filter.val=failed"])
 
     const {data} = useInstances(Config.url, true, namespace, localStorage.getItem("apikey"), ...qParams)
     
@@ -258,7 +258,7 @@ function FailedExecutions(props) {
 
 function SuccessfulExecutions(props) {
     const {namespace} = props
-    const [qParams] = useState(["first=10", "filter.field=STATUS", "filter.type=MATCH", "filter.val=complete"])
+    const [qParams] = useState(["first=5", "filter.field=STATUS", "filter.type=MATCH", "filter.val=complete"])
 
     const {data} = useInstances(Config.url, true, namespace, localStorage.getItem("apikey"), ...qParams)
     // todo implement loading


### PR DESCRIPTION
Signed-off-by: Jens Gerke <jens.gerke@direktiv.io>

Change the pagination count to 10 for instances, explorer and to 8 for events