### PR TITLE
git: soft and hard sync removed and replaced with just sync

### DIFF
--- a/src/layouts/mirror/index.js
+++ b/src/layouts/mirror/index.js
@@ -133,10 +133,7 @@ export default function MirrorPage(props) {
                         </Button>
                     )}
                     actionButtons={[
-                        ButtonDefinition("Soft Sync", async () => {
-                            await syncRef.current()
-                        }, "small blue", () => { }, true, false),
-                        ButtonDefinition("Hard Sync", async () => {
+                        ButtonDefinition("Sync", async () => {
                             await syncRef.current(true)
                         }, "small blue", () => { }, true, false),
                         ButtonDefinition("Cancel", () => { }, "small light", () => { }, true, false)
@@ -144,7 +141,7 @@ export default function MirrorPage(props) {
                 >
                     <FlexBox className="col gap" style={{ paddingTop: "8px" }}>
                         <FlexBox className="col center info-update-label">
-                            Would you like to do a normal sync or force a hard sync?
+                          Fetch and sync mirror with latest content from remote repository?
                         </FlexBox>
                     </FlexBox>
                 </Modal>


### PR DESCRIPTION
Signed-off-by: jalfvort <jon.alfaro@direktiv.io>

## Description

Soft and hard sync removed from mirror info page and replaced with just sync

## Purpose

- [ ] Bug fix
- [ ] New feature
- [ ] Other

## How was this tested? (if applicable)

Please describe how the proposed changes have been tested, and the outcome of the tests.

## Test Platform Details (if applicable)

**Operating system:** OSX/Windows 10/Ubuntu 20.04/etc.

**CLI version:**

**Hypervisors/Platforms (if applicable):** qemu/hyper-v/google cloud platform/vmware workstation/etc

**Kernel version (if applicable):**

## Checklist

- [ ] Code is commented
- [ ] Unit test coverage encompasses new code
- [ ] Existing unit tests pass with these changes
- [ ] PR is signed
