### PR TITLE
Ngnix added to Dockerfile to replace webserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17 as gui-build
+FROM node:17 as build
 
 ARG FULL_VERSION
 
@@ -12,28 +12,14 @@ COPY src ./src
 COPY package.json ./
 COPY yarn.lock ./
 
-RUN yarn add direktiv-react-hooks
 RUN yarn install
 # If this causes problems on github actions: A potential fix is to change the builder image to `node:alpine`
 RUN NODE_OPTIONS=--openssl-legacy-provider REACT_APP_VERSION=$FULL_VERSION yarn build
 
-FROM golang:1.16-buster as server-build
+# production environment
+FROM nginx:stable-alpine
 
-RUN apt-get update && apt-get install git -y
-RUN git clone https://github.com/direktiv/reactjs-embed.git;
-
-WORKDIR /go/src/app
-RUN cp /go/reactjs-embed/* /go/src/app/
-
-COPY --from=gui-build /app/build /go/src/app/build
-
-RUN go mod download
-RUN CGO_ENABLED=0 go build -o /server -ldflags="-s -w" main.go
-
-FROM alpine:latest
-
-RUN apk add shadow
-RUN /usr/sbin/groupadd -g 22222 direktivg && /usr/sbin/useradd -s /bin/sh -g 22222 -u 33333 direktivu
-
-COPY --from=server-build /server /
-CMD ["/server"]
+COPY --from=build /app/build /usr/share/nginx/html
+COPY conf/nginx.conf /etc/nginx/conf.d/default.conf
+ 
+CMD ["nginx", "-g", "daemon off;"]

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 8080;
+  listen [::]:8080;
+  root /usr/share/nginx/html;
+  include /etc/nginx/mime.types;
+
+  location / {
+    try_files $uri /index.html;  
+  }
+
+}


### PR DESCRIPTION
Signed-off-by: jalfvort <jon.alfaro@direktiv.io>

## Description

We are moving from our reactjs-embeded server to nginx on release 0.7. The depencey to our legacy webserver: https://github.com/direktiv/reactjs-embed is removed in this PR and is replaced with the OTS solution Nginx.

Reason for removal:  The original reason for reactjs-embed (Configuration injection into built javascript files) is no longer required.

## Related Issue
https://github.com/direktiv/direktiv/issues/619

## Related Pull Requests
https://github.com/direktiv/direktiv-ui-ee/pull/16
https://github.com/direktiv/direktiv-ui/pull/323
https://github.com/direktiv/direktiv-charts/pull/24
