### PR TITLE
Disable stream requests on namespaces, mirrors, and file explorer.

### DIFF
--- a/src/layouts/explorer/index.js
+++ b/src/layouts/explorer/index.js
@@ -177,7 +177,7 @@ function ExplorerList(props) {
 
     const [orderFieldKey, setOrderFieldKey] = useState(orderFieldKeys[0])
 
-    const [streamNodes, setStreamNodes] = useState(true)
+    const [streamNodes, setStreamNodes] = useState(false)
     const [queryParams, setQueryParams] = useState([])
 
     const pageHandler = usePageHandler(PAGE_SIZE)
@@ -214,7 +214,7 @@ function ExplorerList(props) {
     })
 
     useEffect(()=>{
-        setStreamNodes(true)
+        setStreamNodes(false)
     },[path])
 
     useEffect(()=>{

--- a/src/layouts/main/index.js
+++ b/src/layouts/main/index.js
@@ -158,7 +158,7 @@ function MainLayout(props) {
  
     const [namespace, setNamespace] = useState(null)
     const [toggleResponsive, setToggleResponsive] = useState(false);
-    const {data, err, createNamespace, createMirrorNamespace, deleteNamespace} = useNamespaces(Config.url, true, akey)
+    const {data, err, createNamespace, createMirrorNamespace, deleteNamespace} = useNamespaces(Config.url, false, akey)
 
     // const [versions, setVersions] = useState(false)
     

--- a/src/layouts/namespace-services/index.js
+++ b/src/layouts/namespace-services/index.js
@@ -83,7 +83,7 @@ function NamespaceServices(props) {
     const [cmd, setCmd] = useState("")
     const [maxScale, setMaxScale] = useState(0)
 
-    const {data, err, config, getNamespaceConfig, getNamespaceServices, createNamespaceService, deleteNamespaceService} = useNamespaceServices(Config.url, true, namespace, localStorage.getItem("apikey"))
+    const {data, err, config, getNamespaceConfig, getNamespaceServices, createNamespaceService, deleteNamespaceService} = useNamespaceServices(Config.url, false, namespace, localStorage.getItem("apikey"))
 
     useEffect(()=>{
         async function getcfg() {


### PR DESCRIPTION
## Description

This PR toggles the UI to send normal get requests on namespaces, mirrors, and file explorer.
We still need the streams on logs, events and instances.