### PR TITLE
draft: [dir 458] webkit workaround

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,6 @@
 name: Playwright Tests
 on:
-  push
+  pull_request
   # push:
   #   branches: [main, ]
   # pull_request:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,9 @@ const baseURL = `${process.env.VITE_E2E_UI_HOST}:${process.env.VITE_E2E_UI_PORT}
 export default defineConfig({
   testDir: "./e2e",
   /* Run tests in files in parallel */
-  fullyParallel: true,
+  // Running in parallel should be possible, but as every test will spam a new
+  // namespace this will clutter up the interface.
+  fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */


### PR DESCRIPTION
Please do not merge, we should discuss this first.

See the comments in the file.

This will "force" clicks only in the context where this is needed (when tests run locally on webkit).

However, I am not really comfortable with the logical complexity this adds to the tests. I think I'd rather keep them simple and live with tests failing locally in webkit until we know more.