### PR TITLE
draft: [DIR-606] add filters for Event History

### DIFF
--- a/src/layouts/events/index.jsx
+++ b/src/layouts/events/index.jsx
@@ -9,7 +9,7 @@ import ContentPanel, {
 } from "../../components/content-panel";
 import Pagination, { usePageHandler } from "../../components/pagination";
 import { VscClose, VscCloud, VscDebugStepInto, VscPlay } from "react-icons/vsc";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { AutoSizer } from "react-virtualized";
 import { Config } from "../../util";
@@ -78,6 +78,11 @@ function EventsPage(props) {
 
   const historyPageHandler = usePageHandler(PAGE_SIZE);
   const listenersPageHandler = usePageHandler(PAGE_SIZE);
+
+  // Reset pagination when filter params have changed
+  useEffect(() => {
+    historyPageHandler.updatePage(1);
+  }, [historyPageHandler, queryFilters]);
 
   const {
     eventHistory,

--- a/src/layouts/events/index.jsx
+++ b/src/layouts/events/index.jsx
@@ -8,7 +8,8 @@ import ContentPanel, {
   ContentPanelTitleIcon,
 } from "../../components/content-panel";
 import Pagination, { usePageHandler } from "../../components/pagination";
-import { VscCloud, VscDebugStepInto, VscPlay } from "react-icons/vsc";
+import { VscClose, VscCloud, VscDebugStepInto, VscPlay } from "react-icons/vsc";
+import { useMemo, useState } from "react";
 
 import { AutoSizer } from "react-virtualized";
 import { Config } from "../../util";
@@ -20,7 +21,6 @@ import Modal from "../../components/modal";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { useApiKey } from "../../util/apiKeyProvider";
 import { useEvents } from "../../hooks";
-import { useState } from "react";
 import utc from "dayjs/plugin/utc";
 
 dayjs.extend(utc);
@@ -43,6 +43,37 @@ function EventsPage(props) {
   const { namespace } = props;
   const [apiKey] = useApiKey();
 
+  const [filterByType, setFilterByType] = useState("");
+  const [filterCreatedBefore, setFilterCreatedBefore] = useState("");
+  const [filterCreatedAfter, setFilterCreatedAfter] = useState("");
+
+  const queryFilters = useMemo(() => {
+    const newFilters = [];
+    if (filterByType !== "") {
+      newFilters.push(
+        `filter.field=TYPE&filter.type=MATCH&filter.val=${filterByType}`
+      );
+    }
+
+    if (filterCreatedBefore !== "") {
+      newFilters.push(
+        `filter.field=CREATED&filter.type=BEFORE&filter.val=${encodeURIComponent(
+          new Date(filterCreatedBefore).toISOString()
+        )}`
+      );
+    }
+
+    if (filterCreatedAfter !== "") {
+      newFilters.push(
+        `filter.field=CREATED&filter.type=AFTER&filter.val=${encodeURIComponent(
+          new Date(filterCreatedAfter).toISOString()
+        )}`
+      );
+    }
+
+    return newFilters;
+  }, [filterByType, filterCreatedBefore, filterCreatedAfter]);
+
   // errHistory and errListeners TODO show error if one
 
   const historyPageHandler = usePageHandler(PAGE_SIZE);
@@ -57,11 +88,112 @@ function EventsPage(props) {
     replayEvent,
   } = useEvents(Config.url, true, namespace, apiKey, {
     listeners: [listenersPageHandler.pageParams],
-    history: [historyPageHandler.pageParams],
+    history: [historyPageHandler.pageParams, ...queryFilters],
   });
 
   return (
     <>
+      <FlexBox
+        className="gap instance-filter"
+        style={{
+          justifyContent: "space-between",
+          alignItems: "center",
+          paddingBottom: "8px",
+          flexGrow: "0",
+        }}
+      >
+        <FlexBox col gap>
+          {/* FILTERS START */}
+
+          <FlexBox
+            className="gap instance-filter"
+            style={{
+              justifyContent: "space-between",
+              alignItems: "center",
+              paddingBottom: "8px",
+              flexGrow: "0",
+            }}
+          >
+            <FlexBox col gap>
+              <FlexBox row gap center="y">
+                Filter History by Type
+                {filterByType === "" ? null : (
+                  <div
+                    className="filter-close-btn"
+                    onClick={() => {
+                      setFilterByType("");
+                    }}
+                  >
+                    <VscClose />
+                  </div>
+                )}
+              </FlexBox>
+              <input
+                type="search"
+                placeholder="Event Type"
+                value={filterByType}
+                onChange={(e) => {
+                  setFilterByType(e.target.value);
+                }}
+              />
+            </FlexBox>
+            <FlexBox col gap>
+              <FlexBox row gap center="y">
+                Filter Created Before
+                {filterCreatedBefore === "" ? null : (
+                  <div
+                    className="filter-close-btn"
+                    onClick={() => {
+                      setFilterCreatedBefore("");
+                    }}
+                  >
+                    <VscClose />
+                  </div>
+                )}
+              </FlexBox>
+              <input
+                type="datetime-local"
+                style={{
+                  color: `${filterCreatedBefore === "" ? "gray" : "#082032"}`,
+                }}
+                value={filterCreatedBefore}
+                required
+                onChange={(e) => {
+                  setFilterCreatedBefore(e.target.value);
+                }}
+              />
+            </FlexBox>
+            <FlexBox col gap>
+              <FlexBox row gap center="y">
+                Filter Created After
+                {filterCreatedAfter === "" ? null : (
+                  <div
+                    className="filter-close-btn"
+                    onClick={() => {
+                      setFilterCreatedAfter("");
+                    }}
+                  >
+                    <VscClose />
+                  </div>
+                )}
+              </FlexBox>
+              <input
+                type="datetime-local"
+                style={{
+                  color: `${filterCreatedAfter === "" ? "gray" : "#082032"}`,
+                }}
+                value={filterCreatedAfter}
+                required
+                onChange={(e) => {
+                  setFilterCreatedAfter(e.target.value);
+                }}
+              />
+            </FlexBox>
+          </FlexBox>
+
+          {/* FILTERS END */}
+        </FlexBox>
+      </FlexBox>
       <FlexBox col gap style={{ paddingRight: "8px" }}>
         <FlexBox>
           <ContentPanel style={{ width: "100%" }}>
@@ -128,7 +260,7 @@ function EventsPage(props) {
                               {dayjs
                                 .utc(obj.receivedAt)
                                 .local()
-                                .format("HH:mm:ss a")}
+                                .format("DD MMM YYYY HH:mm:ss")}
                             </td>
                             <td
                               style={{


### PR DESCRIPTION
## Description

Changes: 
- Events can now be filtered by:
  - Event type (needs to be an exact match)
  - Created before date/time
  - Created after date/time
- pagination offset is reset to page 1 when filters have changed
- events list now shows date + time (before it was only time)

## Pending TBD in backend

- Currently, pagination is applied before filtering, so events are only found if you are already on the correct page of results. A fix is in the works.

## Notes for reviewer

Code review:
- The filters were copied and adapted from the instances page
- The filter params just had to be passed on to the useEvents hook, no further changes necessary.

Testing the feature:
- You can use the "Send New Event" button on the events page to populate the list.
- To create multiple events, update the id in the template (it's hard coded, needs to be unique)
- Create enough events to have 2 pages of events. Make sure that you find the expected events irrespective of the page you are on before you set the filters.
- When searching by event type, only exact matches are found


