### PR TITLE
[DIR-627] Settings: loading states

### DIFF
--- a/src/pages/namespace/Settings/Registries/index.tsx
+++ b/src/pages/namespace/Settings/Registries/index.tsx
@@ -21,7 +21,7 @@ const RegistriesList: FC = () => {
   const [deleteRegistry, setDeleteRegistry] = useState<RegistrySchemaType>();
   const [createRegistry, setCreateRegistry] = useState(false);
 
-  const registries = useRegistries();
+  const { data, isFetched } = useRegistries();
 
   const { mutate: deleteRegistryMutation } = useDeleteRegistry({
     onSuccess: () => {
@@ -36,6 +36,8 @@ const RegistriesList: FC = () => {
       setCreateRegistry(false);
     }
   }, [dialogOpen]);
+
+  if (!isFetched) return null;
 
   return (
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
@@ -52,10 +54,10 @@ const RegistriesList: FC = () => {
       </div>
 
       <Card>
-        {registries.data?.registries.length ? (
+        {data?.registries.length ? (
           <Table>
             <TableBody>
-              {registries.data?.registries.map((item, i) => (
+              {data?.registries.map((item, i) => (
                 <ItemRow key={i} item={item} onDelete={setDeleteRegistry} />
               ))}
             </TableBody>

--- a/src/pages/namespace/Settings/Secrets/index.tsx
+++ b/src/pages/namespace/Settings/Secrets/index.tsx
@@ -21,7 +21,7 @@ const SecretsList: FC = () => {
   const [deleteSecret, setDeleteSecret] = useState<SecretSchemaType>();
   const [createSecret, setCreateSecret] = useState(false);
 
-  const secrets = useSecrets();
+  const { data, isFetched } = useSecrets();
 
   const { mutate: deleteSecretMutation } = useDeleteSecret({
     onSuccess: () => {
@@ -36,6 +36,8 @@ const SecretsList: FC = () => {
       setCreateSecret(false);
     }
   }, [dialogOpen]);
+
+  if (!isFetched) return null;
 
   return (
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
@@ -52,10 +54,10 @@ const SecretsList: FC = () => {
       </div>
 
       <Card>
-        {secrets.data?.secrets.results.length ? (
+        {data?.secrets.results.length ? (
           <Table>
             <TableBody>
-              {secrets.data?.secrets.results.map((item, i) => (
+              {data?.secrets.results.map((item, i) => (
                 <ItemRow item={item} key={i} onDelete={setDeleteSecret} />
               ))}
             </TableBody>

--- a/src/pages/namespace/Settings/Variables/Edit.tsx
+++ b/src/pages/namespace/Settings/Variables/Edit.tsx
@@ -42,7 +42,7 @@ const Edit = ({ item, onSuccess }: EditProps) => {
   const { t } = useTranslation();
   const theme = useTheme();
 
-  const varContent = useVarContent(item.name);
+  const { data, isFetched } = useVarContent(item.name);
 
   const [body, setBody] = useState<string | undefined>();
   const [mimeType, setMimeType] = useState<MimeTypeType>(fallbackMimeType);
@@ -64,10 +64,10 @@ const Edit = ({ item, onSuccess }: EditProps) => {
   });
 
   useEffect(() => {
-    if (!isInitialized && varContent.isFetched) {
-      setBody(varContent.data?.body);
+    if (!isInitialized && isFetched) {
+      setBody(data?.body);
 
-      const contentType = varContent.data?.headers["content-type"];
+      const contentType = data?.headers["content-type"];
 
       const safeParsedContentType = MimeTypeSchema.safeParse(contentType);
       if (!safeParsedContentType.success) {
@@ -79,7 +79,7 @@ const Edit = ({ item, onSuccess }: EditProps) => {
       setEditorLanguage(mimeTypeToLanguageDict[safeParsedContentType.data]);
       setIsInitialized(true);
     }
-  }, [varContent, isInitialized]);
+  }, [data, isFetched, isInitialized]);
 
   const { mutate: updateVarMutation } = useUpdateVar({
     onSuccess,
@@ -91,37 +91,38 @@ const Edit = ({ item, onSuccess }: EditProps) => {
 
   return (
     <DialogContent>
-      {varContent.isFetched && (
-        <form
-          id="edit-variable"
-          onSubmit={handleSubmit(onSubmit)}
-          className="flex flex-col space-y-5"
-        >
-          <DialogHeader>
-            <DialogTitle>
-              <Trash />
-              <Trans
-                i18nKey="pages.settings.variables.edit.title"
-                values={{ name: item.name }}
-              />
-            </DialogTitle>
-          </DialogHeader>
-
-          <FormErrors errors={errors} className="mb-5" />
-
-          <fieldset className="flex items-center gap-5">
-            <label className="w-[150px] text-right" htmlFor="mimetype">
-              {t("pages.settings.variables.edit.mimeType.label")}
-            </label>
-            <MimeTypeSelect
-              id="mimetype"
-              mimeType={mimeType}
-              onChange={setMimeType}
+      <form
+        id="edit-variable"
+        onSubmit={handleSubmit(onSubmit)}
+        className="flex flex-col space-y-5"
+      >
+        <DialogHeader>
+          <DialogTitle>
+            <Trash />
+            <Trans
+              i18nKey="pages.settings.variables.edit.title"
+              values={{ name: item.name }}
             />
-          </fieldset>
+          </DialogTitle>
+        </DialogHeader>
 
-          <Card className="grow p-4 pl-0" background="weight-1">
-            <div className="h-[500px]">
+        <FormErrors errors={errors} className="mb-5" />
+
+        <fieldset className="flex items-center gap-5">
+          <label className="w-[150px] text-right" htmlFor="mimetype">
+            {t("pages.settings.variables.edit.mimeType.label")}
+          </label>
+          <MimeTypeSelect
+            id="mimetype"
+            loading={!isFetched}
+            mimeType={mimeType}
+            onChange={setMimeType}
+          />
+        </fieldset>
+
+        <Card className="grow p-4 pl-0" background="weight-1">
+          <div className="h-[500px]">
+            {isFetched && (
               <Editor
                 value={body}
                 onChange={(newData) => {
@@ -131,25 +132,21 @@ const Edit = ({ item, onSuccess }: EditProps) => {
                 data-testid="variable-editor"
                 language={editorLanguage}
               />
-            </div>
-          </Card>
+            )}
+          </div>
+        </Card>
 
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button variant="ghost">
-                {t("components.button.label.cancel")}
-              </Button>
-            </DialogClose>
-            <Button
-              type="submit"
-              data-testid="var-edit-submit"
-              variant="primary"
-            >
-              {t("components.button.label.save")}
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost">
+              {t("components.button.label.cancel")}
             </Button>
-          </DialogFooter>
-        </form>
-      )}
+          </DialogClose>
+          <Button type="submit" data-testid="var-edit-submit" variant="primary">
+            {t("components.button.label.save")}
+          </Button>
+        </DialogFooter>
+      </form>
     </DialogContent>
   );
 };

--- a/src/pages/namespace/Settings/Variables/MimeTypeSelect.tsx
+++ b/src/pages/namespace/Settings/Variables/MimeTypeSelect.tsx
@@ -42,8 +42,10 @@ const MimeTypeSelect = ({
   id,
   mimeType,
   onChange,
+  loading = false,
 }: {
   id?: string;
+  loading?: boolean;
   mimeType: string | undefined;
   onChange: (value: MimeTypeType) => void;
 }) => {
@@ -51,7 +53,7 @@ const MimeTypeSelect = ({
 
   return (
     <Select value={mimeType} onValueChange={onChange}>
-      <SelectTrigger id={id} variant="outline" block>
+      <SelectTrigger id={id} loading={loading} variant="outline" block>
         <SelectValue
           placeholder={t("pages.settings.variables.edit.mimeType.placeholder")}
         />

--- a/src/pages/namespace/Settings/Variables/index.tsx
+++ b/src/pages/namespace/Settings/Variables/index.tsx
@@ -22,8 +22,8 @@ const VariablesList: FC = () => {
   const [editItem, setEditItem] = useState<VarSchemaType>();
   const [createItem, setCreateItem] = useState(false);
 
-  const data = useVars();
-  const items = data.data?.variables?.results ?? null;
+  const { data, isFetched } = useVars();
+  const items = data?.variables?.results ?? null;
 
   const { mutate: deleteVarMutation } = useDeleteVar({
     onSuccess: () => {
@@ -38,6 +38,8 @@ const VariablesList: FC = () => {
       setEditItem(undefined);
     }
   }, [dialogOpen]);
+
+  if (!isFetched) return null;
 
   return (
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>


### PR DESCRIPTION
Changes:
* Lists on settings page are not rendered before they are fetched to avoid spinners / layout shifts 
* When editing a variable, the editor is not rendered before the content is fetched, and the mimeTypeSelect has a loading spinner.