### PR TITLE
[DIR-630] settings editor focus

### DIFF
--- a/src/pages/namespace/Settings/Variables/Edit.tsx
+++ b/src/pages/namespace/Settings/Variables/Edit.tsx
@@ -128,6 +128,7 @@ const Edit = ({ item, onSuccess }: EditProps) => {
                 onChange={(newData) => {
                   setBody(newData);
                 }}
+                onMount={(editor) => editor.focus()}
                 theme={theme ?? undefined}
                 data-testid="variable-editor"
                 language={editorLanguage}


### PR DESCRIPTION
After DIR-542 has been merged, the Editor components used for creating secrets and variables no longer focus on mount. This is as intended, because the name input should be focused first.

When editing variables, it makes sense to focus the Editor right away. This PR adds that behavior.

Preview at https://direktiv-ui-refs-pull-405-merge.direktiv.dev/sebxian/settings