### PR TITLE
Fix test timing (waitUntil networkidle)

### DIFF
--- a/e2e/explorer/workflow/active.spec.ts
+++ b/e2e/explorer/workflow/active.spec.ts
@@ -53,7 +53,7 @@ const testSaveWorkflow = async (page: Page) => {
     page.getByText(testText),
     "after saving, screen should have the updated text"
   ).toBeVisible();
-  await page.reload({ waitUntil: "load" });
+  await page.reload({ waitUntil: "networkidle" });
   await expect(
     page.getByText(testText),
     "after reloading, screen should have the updated text"
@@ -162,7 +162,7 @@ test("it is possible to revert the revision", async ({ page }) => {
   ).toHaveText("Updated a few seconds ago");
 
   // check both after page reload
-  await page.reload({ waitUntil: "load" });
+  await page.reload({ waitUntil: "networkidle" });
 
   await expect(
     page.getByText(defaultDescription),

--- a/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
+++ b/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
@@ -32,7 +32,8 @@ test('it is possible to open the revision details of the "latest" revision', asy
   });
 
   await page.goto(
-    `/${namespace}/explorer/workflow/revisions/${workflow}?revision=${revision}`
+    `/${namespace}/explorer/workflow/revisions/${workflow}?revision=${revision}`,
+    { waitUntil: "networkidle" }
   );
 
   await expect(
@@ -97,7 +98,8 @@ test("it is possible to revert a revision within the details page", async ({
 
   // open the details page of the second revision
   await page.goto(
-    `/${namespace}/explorer/workflow/revisions/${workflow}?revision=${secondRevisionName}`
+    `/${namespace}/explorer/workflow/revisions/${workflow}?revision=${secondRevisionName}`,
+    { waitUntil: "networkidle" }
   );
   await expect(
     page.getByTestId("revisions-detail-editor"),


### PR DESCRIPTION
This might improve the flaky tests:

I have added `{ waitUntil: "networkidle" }` to some tests that occasionally fail.

In the trails (screenshots), it seemed the page wasn't fully loaded after a `page.reload`, before the failed assertion took place.

The CI pipeline tests for this PR should already tell us if this helped.