### PR TITLE
[DIR 639] Fix flaky tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
     "dist/",
     ".eslintrc.js",
     "env.d.ts",
+    "playwright-report/",
     /**
      * 🚧
      * TODO_HOOKS_TESTS

--- a/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
+++ b/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
@@ -5,6 +5,7 @@ import { noop as basicWorkflow } from "~/pages/namespace/Explorer/Tree/NewWorkfl
 import { createWorkflow } from "~/api/tree/mutate/createWorkflow";
 import { createWorkflowWithThreeRevisions } from "../../../utils/revisions";
 import { faker } from "@faker-js/faker";
+import { radixClick } from "../../../utils/testutils";
 
 let namespace = "";
 
@@ -134,9 +135,9 @@ test("it is possible to navigate from the revision list to the details and back"
   ).toBeVisible();
 });
 
-// TODO: this fails in Webkit
-test.skip("it is possible to revert a revision within the details page", async ({
+test("it is possible to revert a revision within the details page", async ({
   page,
+  browserName,
 }) => {
   const workflow = faker.system.commonFileName("yaml");
   const {
@@ -181,11 +182,15 @@ test.skip("it is possible to revert a revision within the details page", async (
   //   .toBe(expectedEditorContent);
 
   // open and submit revert dialog
-  await page.getByTestId("revisions-detail-revert-btn").click();
-  await page.getByTestId("dialog-revert-revision-btn-submit").click();
 
-  // click the toast button to open the editor
-  await page.getByTestId("workflow-revert-revision-toast-action").click();
+  const revertButton = page.getByTestId("revisions-detail-revert-btn");
+  await radixClick(browserName, revertButton);
+
+  const submitButton = page.getByTestId("dialog-revert-revision-btn-submit");
+  await radixClick(browserName, submitButton);
+
+  const toastButton = page.getByTestId("workflow-revert-revision-toast-action");
+  await radixClick(browserName, toastButton);
 
   await expect
     .poll(

--- a/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
+++ b/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
@@ -41,12 +41,14 @@ test('it is possible to open the revision details of the "latest" revision', asy
     "it displays the revision title"
   ).toContainText(revision);
 
-  const expectedEditorContent = basicWorkflow.data.replaceAll("\n", "");
-
-  await expect(
-    page.getByTestId("revisions-detail-editor"),
-    "it displays the workflow content in the editor"
-  ).toContainText(expectedEditorContent);
+  const expectedEditorContent = basicWorkflow.data;
+  const textArea = page.getByRole("textbox");
+  await expect
+    .poll(
+      async () => await textArea.inputValue(),
+      "it displays the workflow content in the editor"
+    )
+    .toBe(expectedEditorContent);
 });
 
 test("it is possible to navigate from the revision list to the details and back", async ({
@@ -94,13 +96,14 @@ test("it is possible to revert a revision within the details page", async ({
   // check the content of the latest revision
   await page.goto(`/${namespace}/explorer/workflow/active/${workflow}`);
 
-  let expectedEditorContent = atob(
-    latestRevisions?.revision?.source
-  ).replaceAll("\n", "");
-  await expect(
-    page.getByTestId("workflow-editor"),
-    "it displays the latest workflow content in the editor"
-  ).toContainText(expectedEditorContent);
+  let expectedEditorContent = atob(latestRevisions?.revision?.source);
+  const textArea = page.getByRole("textbox");
+  await expect
+    .poll(
+      async () => await textArea.inputValue(),
+      "it displays the latest workflow content in the editor"
+    )
+    .toBe(expectedEditorContent);
 
   // open the details page of the second revision
   await page.goto(
@@ -108,17 +111,15 @@ test("it is possible to revert a revision within the details page", async ({
     { waitUntil: "networkidle" }
   );
 
-  expectedEditorContent = atob(secondRevision?.revision?.source).replaceAll(
-    "\n",
-    ""
-  );
+  expectedEditorContent = atob(secondRevision?.revision?.source);
 
-  await expect(
-    page.getByTestId("revisions-detail-editor"),
-    "it displays the reverted workflow content in the editor"
-  ).toContainText(expectedEditorContent, {
-    timeout: 10000,
-  });
+  await expect
+    .poll(
+      async () => await textArea.inputValue(),
+      "it displays the reverted workflow content in the editor"
+    )
+    .toBe(expectedEditorContent);
+
   // open and submit revert dialog
   await page.getByTestId(`revisions-detail-revert-btn`).click();
   await page.getByTestId(`dialog-revert-revision-btn-submit`).click();
@@ -126,12 +127,12 @@ test("it is possible to revert a revision within the details page", async ({
   // click the toast button to open the editor
   await page.getByTestId("workflow-revert-revision-toast-action").click();
 
-  await expect(
-    page.getByTestId("workflow-editor"),
-    "it displays the reverted workflow content in the editor"
-  ).toContainText(expectedEditorContent, {
-    timeout: 10000,
-  });
+  await expect
+    .poll(
+      async () => await textArea.inputValue(),
+      "it displays the reverted workflow content in the editor"
+    )
+    .toBe(expectedEditorContent);
 });
 
 test('it does not show the actions button on the revision details of the "latest" revision', async ({

--- a/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
+++ b/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
@@ -52,11 +52,10 @@ test('it is possible to open the revision details of the "latest" revision', asy
     .toBe(expectedEditorContent);
 });
 
-// This test is flaky. Ideally, asserting that the editor content is loaded
-// would be one step in the longer tests below. These steps are currently commented
-// out to reduce the number of flaky tests, and this test has been added keep
-// track of the problem.
-test("it is possible to view the content of an older revision", async ({
+// Skipped because it is redundant; checking the editor content is part of other
+// tests below. But in case there are problems with this step, it may be helpful
+// to reactivate this test to troubleshoot the issue in isolation.
+test.skip("it is possible to view the content of an older revision", async ({
   page,
 }) => {
   // setup test data
@@ -109,22 +108,17 @@ test("it is possible to navigate from the revision list to the details and back"
     "it navigated to the revision details and shows the title"
   ).toContainText(secondRevisionName);
 
-  // The following step is commented out because it often fails in the CI.
-  // For unknown reasons, sometimes no data seems to be loaded into the editor.
-  // There is a separate test above this that only tests this step.
+  const expectedEditorContent = atob(secondRevision.revision.source);
+  const textArea = page.getByRole("textbox");
 
-  // Ideally, we'll find a way to fix the flaky behavior in the future, and
-  // enable the step below. But as long as this step is flaky, it is better
-  // to have it in a separate step, so it is easier to track it.
-
-  // const expectedEditorContent = atob(secondRevision.revision.source);
-  // const textArea = page.getByRole("textbox");
-  // await expect
-  //   .poll(
-  //     async () => await textArea.inputValue(),
-  //     "it displays the workflow content in the editor"
-  //   )
-  //   .toBe(expectedEditorContent);
+  // if this step fails, there is a separate test (currently skipped) that you can
+  // use to troubleshoot: "it is possible to view the content of an older revision"
+  await expect
+    .poll(
+      async () => await textArea.inputValue(),
+      "it displays the workflow content in the editor"
+    )
+    .toBe(expectedEditorContent);
 
   // go back to list page
   await page.getByTestId(`revisions-detail-back-link`).click();
@@ -166,20 +160,14 @@ test("it is possible to revert a revision within the details page", async ({
 
   expectedEditorContent = atob(secondRevision?.revision?.source);
 
-  // The following step is commented out because it often fails in the CI.
-  // For unknown reasons, sometimes no data seems to be loaded into the editor.
-  // There is a separate test above this that only tests this step.
-
-  // Ideally, we'll find a way to fix the flaky behavior in the future, and
-  // enable the step below. But as long as this step is flaky, it is better
-  // to have it in a separate step, so it is easier to track it.
-
-  // await expect
-  //   .poll(
-  //     async () => await textArea.inputValue(),
-  //     "it displays the reverted workflow content in the editor"
-  //   )
-  //   .toBe(expectedEditorContent);
+  // if this step fails, there is a separate test (currently skipped) that you can
+  // use to troubleshoot: "it is possible to view the content of an older revision"
+  await expect
+    .poll(
+      async () => await textArea.inputValue(),
+      "it displays the reverted workflow content in the editor"
+    )
+    .toBe(expectedEditorContent);
 
   // open and submit revert dialog
 

--- a/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
+++ b/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
@@ -51,9 +51,10 @@ test('it is possible to open the revision details of the "latest" revision', asy
     .toBe(expectedEditorContent);
 });
 
-// This test is redundant with a portion of the test below it.
-// Since loading the editor data sometimes fails, having both test cases may help us learn
-// more about the issue. Once the issue is solved, we can get rid of this separate test.
+// This test is flaky. Ideally, asserting that the editor content is loaded
+// would be one step in the longer tests below. These steps are currently commented
+// out to reduce the number of flaky tests, and this test has been added keep
+// track of the problem.
 test("it is possible to view the content of an older revision", async ({
   page,
 }) => {
@@ -107,17 +108,22 @@ test("it is possible to navigate from the revision list to the details and back"
     "it navigated to the revision details and shows the title"
   ).toContainText(secondRevisionName);
 
-  // assert that editor content is loaded
-  // this step is redundant with "it is possible to view the content of an older revision"
-  // see comments there
-  const expectedEditorContent = atob(secondRevision.revision.source);
-  const textArea = page.getByRole("textbox");
-  await expect
-    .poll(
-      async () => await textArea.inputValue(),
-      "it displays the workflow content in the editor"
-    )
-    .toBe(expectedEditorContent);
+  // The following step is commented out because it often fails in the CI.
+  // For unknown reasons, sometimes no data seems to be loaded into the editor.
+  // There is a separate test above this that only tests this step.
+
+  // Ideally, we'll find a way to fix the flaky behavior in the future, and
+  // enable the step below. But as long as this step is flaky, it is better
+  // to have it in a separate step, so it is easier to track it.
+
+  // const expectedEditorContent = atob(secondRevision.revision.source);
+  // const textArea = page.getByRole("textbox");
+  // await expect
+  //   .poll(
+  //     async () => await textArea.inputValue(),
+  //     "it displays the workflow content in the editor"
+  //   )
+  //   .toBe(expectedEditorContent);
 
   // go back to list page
   await page.getByTestId(`revisions-detail-back-link`).click();
@@ -159,12 +165,12 @@ test("it is possible to revert a revision within the details page", async ({
   expectedEditorContent = atob(secondRevision?.revision?.source);
 
   // The following step is commented out because it often fails in the CI.
-  // For unknown reasons, no data seems to be loaded into the editor).
-  // The tests above this one already make sure that the revisions detail editor
-  // works in principle, thus it is ok to skip this part for now.
-  // Ideally, we'll find a way to fix this flaky behavior in the future.
-  // Interestingly, the other editor instance that is tested further below
-  // does not have this problem.
+  // For unknown reasons, sometimes no data seems to be loaded into the editor.
+  // There is a separate test above this that only tests this step.
+
+  // Ideally, we'll find a way to fix the flaky behavior in the future, and
+  // enable the step below. But as long as this step is flaky, it is better
+  // to have it in a separate step, so it is easier to track it.
 
   // await expect
   //   .poll(

--- a/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
+++ b/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
@@ -134,7 +134,8 @@ test("it is possible to navigate from the revision list to the details and back"
   ).toBeVisible();
 });
 
-test("it is possible to revert a revision within the details page", async ({
+// TODO: this fails in Webkit
+test.skip("it is possible to revert a revision within the details page", async ({
   page,
 }) => {
   const workflow = faker.system.commonFileName("yaml");

--- a/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
+++ b/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
@@ -180,8 +180,8 @@ test("it is possible to revert a revision within the details page", async ({
   //   .toBe(expectedEditorContent);
 
   // open and submit revert dialog
-  await page.getByTestId(`revisions-detail-revert-btn`).click();
-  await page.getByTestId(`dialog-revert-revision-btn-submit`).click();
+  await page.getByTestId("revisions-detail-revert-btn").click();
+  await page.getByTestId("dialog-revert-revision-btn-submit").click();
 
   // click the toast button to open the editor
   await page.getByTestId("workflow-revert-revision-toast-action").click();

--- a/e2e/explorer/workflow/revisions/revisionsList.spec.ts
+++ b/e2e/explorer/workflow/revisions/revisionsList.spec.ts
@@ -131,14 +131,13 @@ test("it is possible to revert to the previous the workflow in the revisions lis
   await actionWaitForSuccessToast(page);
   await page.goto(`${namespace}/explorer/workflow/active/${name}`);
 
-  const expectedEditorContent = firstContent.replaceAll("\n", "");
-
-  await expect(
-    page.getByTestId("workflow-editor"),
-    "it displays the reverted workflow content in the editor"
-  ).toContainText(expectedEditorContent, {
-    timeout: 10000,
-  });
+  const textArea = page.getByRole("textbox");
+  await expect
+    .poll(
+      async () => await textArea.inputValue(),
+      "it displays the reverted workflow content in the editor"
+    )
+    .toBe(firstContent);
 });
 
 test("it is possible to delete the revision", async ({ page }) => {

--- a/e2e/explorer/workflow/revisions/revisionsList.spec.ts
+++ b/e2e/explorer/workflow/revisions/revisionsList.spec.ts
@@ -130,12 +130,15 @@ test("it is possible to revert to the previous the workflow in the revisions lis
   await btnRevert.click();
   await actionWaitForSuccessToast(page);
   await page.goto(`${namespace}/explorer/workflow/active/${name}`);
-  const textArea = page.getByRole("textbox");
-  const workflowValue = await textArea.inputValue();
-  expect(
-    workflowValue,
-    "after revert, it should be the same as the first updated workflow"
-  ).toBe(firstContent);
+
+  const expectedEditorContent = firstContent.replaceAll("\n", "");
+
+  await expect(
+    page.getByTestId("workflow-editor"),
+    "it displays the reverted workflow content in the editor"
+  ).toContainText(expectedEditorContent, {
+    timeout: 10000,
+  });
 });
 
 test("it is possible to delete the revision", async ({ page }) => {

--- a/e2e/explorer/workflow/utils.ts
+++ b/e2e/explorer/workflow/utils.ts
@@ -2,14 +2,11 @@ import { Page, expect } from "@playwright/test";
 
 export const actionWaitForSuccessToast = async (page: Page) => {
   const successToast = page.getByTestId("toast-success");
-  await expect(
-    successToast,
-    "success toast should appear after revert action button click"
-  ).toBeVisible();
+  await expect(successToast, "a success toast appears").toBeVisible();
   await page.getByTestId("toast-close").click();
   await expect(
     successToast,
-    "success toast should disappear after click toast-close"
+    "success toast disappears after clicking toast-close"
   ).toBeHidden();
 };
 

--- a/e2e/settings/index.spec.ts
+++ b/e2e/settings/index.spec.ts
@@ -178,10 +178,13 @@ test("it is possible to create and delete variables", async ({ page }) => {
   await page.getByTestId(subjectDropdownSelector).click();
   await page.getByTestId("dropdown-actions-edit").click();
 
-  await expect(
-    page.getByTestId("variable-editor-card"),
-    "the variable's content is loaded into the editor"
-  ).toContainText(newVariable.value);
+  const textArea = page.getByRole("textbox");
+  await expect
+    .poll(
+      async () => await textArea.inputValue(),
+      "the variable's content is loaded into the editor"
+    )
+    .toBe(newVariable.value);
 
   await expect(
     page.locator("select"),
@@ -228,19 +231,19 @@ test("it is possible to edit variables", async ({ page }) => {
   await page.getByTestId(subjectDropdownSelector).click();
   await page.getByTestId("dropdown-actions-edit").click();
 
-  await expect(
-    page.getByTestId("variable-editor-card"),
-    "the variable's content is loaded into the editor"
-  ).toContainText(subject.content, {
-    timeout: 10000,
-  });
+  const textArea = page.getByRole("textbox");
+  await expect
+    .poll(
+      async () => await textArea.inputValue(),
+      "the variable's content is loaded into the editor"
+    )
+    .toBe(subject.content);
 
   await expect(
     page.locator("select"),
     "MimeTypeSelect is set to the subject's mimeType"
   ).toHaveValue(subject.mimeType);
 
-  const textArea = page.getByRole("textbox");
   await textArea.type(faker.random.alphaNumeric(10));
   const updatedValue = await textArea.inputValue();
   const updatedType =
@@ -257,13 +260,15 @@ test("it is possible to edit variables", async ({ page }) => {
   await page.getByTestId(subjectDropdownSelector).click();
   await page.getByTestId("dropdown-actions-edit").click();
 
-  await expect(
-    page.getByTestId("variable-editor-card"),
-    "the variable's content is loaded into the editor"
-  ).toContainText(updatedValue);
+  await expect
+    .poll(
+      async () => await textArea.inputValue(),
+      "the updated variable content is loaded into the editor"
+    )
+    .toBe(updatedValue);
 
   await expect(
     page.locator("select"),
-    "MimeTypeSelect is set to the subject's mimeType"
+    "MimeTypeSelect is set to the updated mimeType"
   ).toHaveValue(updatedType);
 });

--- a/e2e/settings/index.spec.ts
+++ b/e2e/settings/index.spec.ts
@@ -7,6 +7,7 @@ import { createRegistries } from "../utils/registries";
 import { createSecrets } from "../utils/secrets";
 import { createVariables } from "../utils/variables";
 import { faker } from "@faker-js/faker";
+import { radixClick } from "../utils/testutils";
 
 const { options } = MimeTypeSchema;
 
@@ -146,7 +147,10 @@ test("it is possible to create and delete registries", async ({ page }) => {
   ).toHaveCount(0);
 });
 
-test("it is possible to create and delete variables", async ({ page }) => {
+test("it is possible to create and delete variables", async ({
+  page,
+  browserName,
+}) => {
   const variables = await createVariables(namespace, 3);
   const variableToDelete = variables[2];
   // handle error to avoid typescript errors below
@@ -190,7 +194,9 @@ test("it is possible to create and delete variables", async ({ page }) => {
     page.locator("select"),
     "MimeTypeSelect is set to the subject's mimeType"
   ).toHaveValue(newVariable.mimeType);
-  await page.getByTestId("var-edit-cancel").click();
+
+  const cancelButton = page.getByTestId("var-edit-cancel");
+  await radixClick(browserName, cancelButton);
 
   //delete one item
   await expect(

--- a/e2e/utils/testutils.ts
+++ b/e2e/utils/testutils.ts
@@ -13,8 +13,8 @@ export const getStyle = async (
  * This is a workaround for a problem with clicking on some elements in Webkit.
  * The .click() method should be used whenever possible. But in some cases,
  * it does not work reliably in Webkit. In these cases, dispatchEvent("click")
- * can be used. The downside is that it triggers the click even without simulating
- * a real click, so it is not a reliable test that the UI works.
+ * works. The downside is that it triggers the click event without simulating
+ * a mouse click, so it is not a reliable test that the UI works.
  *
  * It seems that this problem occurs only with or within Radix UI elements (dropdowns,
  * popups, toasts, etc.).

--- a/e2e/utils/testutils.ts
+++ b/e2e/utils/testutils.ts
@@ -8,3 +8,27 @@ export const getStyle = async (
     (el, property) => window.getComputedStyle(el).getPropertyValue(property),
     property
   );
+
+/**
+ * This is a workaround for a problem with clicking on some elements in Webkit.
+ * The .click() method should be used whenever possible. But in some cases,
+ * it does not work reliably in Webkit. In these cases, dispatchEvent("click")
+ * can be used. The downside is that it triggers the click even without simulating
+ * a real click, so it is not a reliable test that the UI works.
+ *
+ * It seems that this problem occurs only with or within Radix UI elements (dropdowns,
+ * popups, toasts, etc.).
+ *
+ * @param browserName is available in tests with test("...", { page, browserName })
+ * @param locator e.g. page.getByTestid("test-id")
+ */
+export const radixClick = async (
+  browserName: "chromium" | "firefox" | "webkit",
+  locator: Locator
+) => {
+  if (browserName === "webkit") {
+    await locator.dispatchEvent("click");
+  } else {
+    await locator.click();
+  }
+};

--- a/src/pages/namespace/Explorer/Workflow/Revisions/Detail/index.tsx
+++ b/src/pages/namespace/Explorer/Workflow/Revisions/Detail/index.tsx
@@ -33,7 +33,7 @@ const WorkflowRevisionsPage = () => {
   const Icon = isTag ? Tag : GitMerge;
   const isLatest = selectedRevision === "latest";
 
-  if (!path || !namespace || !selectedRevision) return null;
+  if (!path || !namespace || !selectedRevision || !workflowData) return null;
 
   return (
     <div className="flex grow flex-col space-y-4">

--- a/src/pages/namespace/Settings/Variables/Edit.tsx
+++ b/src/pages/namespace/Settings/Variables/Edit.tsx
@@ -126,7 +126,7 @@ const Edit = ({ item, onSuccess }: EditProps) => {
           data-testid="variable-editor-card"
         >
           <div className="h-[500px]">
-            {isFetched && (
+            {isFetched && body && (
               <Editor
                 value={body}
                 onChange={(newData) => {


### PR DESCRIPTION
This fixes several problems which resulted in flaky tests:

* When loading the revisions detail page `namespace/explorer/workflow/revisions` directly (as opposed to navigating there), sometimes in Webkit browsers (e.g. Safari) the editor's content is not loaded. This was solved by adding an early return to the revisions detail page, so the editor is not loaded before the content is fetched.
* Changed the way that the content of the monaco editor is checked. The new method reads the value of the "textbox" element directly and also tries again until the test condition is true (previously reading the textbox value failed when the editor had not finished initializing). 
* Checks of the editor's content have been added to tests where it was visible, but not tested before.
* Some click events often fail in Webkit. This seems to happen with Radix elements only. For some reason, playwright never considers them "settled" and thus never performs the click. I added a workaround helper method `radixClick()` that detects the browser and dispatches the onClick event without simulating a click in Webkit. In Chrome and Firefox, the click() event is still used (because this gives us more confidence that the UI really works).

Some more comments:
* One [test run](https://github.com/direktiv/direktiv-ui/actions/runs/5484967250) didn't have a single flaky test :rocket:, [another one](https://github.com/direktiv/direktiv-ui/actions/runs/5486297486/jobs/9996214751) had only two flaky tests and the [last one](https://github.com/direktiv/direktiv-ui/actions/runs/5486626006/jobs/9996964920) was flawless again. There will still be tests that fail occasionally, but the most problematic ones seem to be fixed.
* The `radixClick()` was only added to tests that fail very frequently. It could potentially be added to many more tests. But I think it is important to wait and evaluate how stable the CI tests are before making sweeping changes. There could be problems introduced by the `radixClick()` method that will only surface in the CI test logs after a few days or weeks. The `radixClick()` method is a compromise with drawbacks (we can be less confident that the UI works as intended in Webkit). I have created a ticket DIR-684 to re-evaluate this at a later time.
