### PR TITLE
[DIR-683] design improvements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,7 +8,7 @@ html,
 .docs-story {
   @apply h-full;
   @apply bg-white dark:bg-black;
-  @apply text-gray-11 dark:text-gray-dark-11;
+  @apply text-gray-12 dark:text-gray-dark-12;
 }
 
 /**

--- a/src/design/Alert/index.tsx
+++ b/src/design/Alert/index.tsx
@@ -21,8 +21,7 @@ const Alert: FC<AlertProps> = ({ variant, className, children, ...props }) => (
         "bg-success-4 text-success-11 dark:bg-success-dark-4 dark:text-success-dark-11",
       variant === "warning" &&
         "bg-warning-4 text-warning-11 dark:bg-warning-dark-4 dark:text-warning-dark-11",
-      variant === undefined &&
-        "bg-gray-4 text-gray-11 dark:bg-gray-dark-4 dark:text-gray-dark-11",
+      variant === undefined && "bg-gray-2 dark:bg-gray-dark-2",
       className
     )}
     {...props}

--- a/src/design/Appshell/index.stories.tsx
+++ b/src/design/Appshell/index.stories.tsx
@@ -48,6 +48,7 @@ import {
   SidebarMain,
   SidebarTop,
 } from "./index";
+import { Tabs, TabsList, TabsTrigger } from "../Tabs";
 
 import Avatar from "../Avatar";
 import Button from "../Button";
@@ -376,22 +377,16 @@ export const MoreDetailedShell = () => {
               </div>
               <div>
                 <nav className="-mb-px flex space-x-8">
-                  {tabs.map((tab) => (
-                    <a
-                      key={tab.name}
-                      href={tab.href}
-                      className={twMergeClsx(
-                        tab.current
-                          ? "border-primary-500 text-primary-500"
-                          : "border-transparent text-gray-11 hover:border-gray-8 hover:text-gray-12 dark:hover:border-gray-dark-8 dark:hover:text-gray-dark-12",
-                        "flex items-center gap-x-2 whitespace-nowrap border-b-2 px-1 pb-4 text-sm font-medium"
-                      )}
-                      aria-current={tab.current ? "page" : undefined}
-                    >
-                      <tab.icon aria-hidden="true" className="h-4 w-auto" />{" "}
-                      {tab.name}
-                    </a>
-                  ))}
+                  <Tabs defaultValue={tabs?.[0]?.name}>
+                    <TabsList>
+                      {tabs.map((tab) => (
+                        <TabsTrigger key={tab.name} value={tab.name}>
+                          <tab.icon aria-hidden="true" className="h-4 w-auto" />{" "}
+                          {tab.name}
+                        </TabsTrigger>
+                      ))}
+                    </TabsList>
+                  </Tabs>
                 </nav>
               </div>
             </div>

--- a/src/design/Checkbox/index.stories.tsx
+++ b/src/design/Checkbox/index.stories.tsx
@@ -36,11 +36,11 @@ export function CheckboxWithText() {
       <div className="grid gap-1.5 leading-none">
         <label
           htmlFor="terms2"
-          className="text-sm font-medium leading-none text-gray-10 peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-gray-dark-10"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
         >
           Accept terms and conditions
         </label>
-        <p className="text-sm text-gray-10 dark:text-gray-dark-10">
+        <p className="text-sm">
           You agree to our Terms of Service and Privacy Policy.
         </p>
       </div>

--- a/src/design/Command/index.stories.tsx
+++ b/src/design/Command/index.stories.tsx
@@ -151,7 +151,7 @@ export function CommandDialogDemo() {
     <>
       <p className="text-sm text-gray-11 dark:text-gray-dark-11">
         Press{" "}
-        <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border border-gray-4 bg-gray-1 px-1.5 font-mono text-[10px] font-medium text-gray-11 opacity-100 dark:border-gray-dark-4 dark:bg-gray-dark-1 dark:text-gray-dark-11">
+        <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border border-gray-4 bg-gray-1 px-1.5 font-mono text-[10px] font-medium opacity-100 dark:border-gray-dark-4 dark:bg-gray-dark-1">
           <span className="text-xs">⌘</span>J
         </kbd>
       </p>

--- a/src/design/Command/index.tsx
+++ b/src/design/Command/index.tsx
@@ -15,8 +15,8 @@ const Command = React.forwardRef<
     ref={ref}
     className={twMergeClsx(
       "flex h-full w-full flex-col overflow-hidden rounded-md",
-      "bg-gray-1 text-gray-11",
-      "dark:bg-gray-dark-1 dark:text-gray-dark-11",
+      "bg-gray-1",
+      "dark:bg-gray-dark-1",
       className
     )}
     {...props}

--- a/src/design/ContextMenu/index.tsx
+++ b/src/design/ContextMenu/index.tsx
@@ -66,8 +66,8 @@ const ContextMenuContent = React.forwardRef<
       ref={ref}
       className={twMergeClsx(
         "z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md  animate-in fade-in-80 ",
-        "border-gray-3 bg-gray-1 ",
-        "dark:border-gray-dark-3 dark:bg-gray-dark-1",
+        "border-gray-3 bg-gray-1 text-gray-11",
+        "dark:border-gray-dark-3 dark:bg-gray-dark-1 dark:text-gray-dark-11",
         className
       )}
       {...props}

--- a/src/design/Dialog/index.tsx
+++ b/src/design/Dialog/index.tsx
@@ -93,8 +93,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={twMergeClsx(
-      "flex items-center gap-2 text-lg font-semibold text-gray-12",
-      "dark:text-gray-dark-12",
+      "flex items-center gap-2 text-lg font-semibold",
       className
     )}
     {...props}

--- a/src/design/Dialog/index.tsx
+++ b/src/design/Dialog/index.tsx
@@ -108,8 +108,8 @@ const DialogDescription = React.forwardRef<
   <DialogPrimitive.Description
     ref={ref}
     className={twMergeClsx(
-      "text-sm text-gray-10",
-      "dark:text-gray-dark-10",
+      "text-sm text-gray-11",
+      "dark:text-gray-dark-11",
       className
     )}
     {...props}

--- a/src/design/Dropdown/index.tsx
+++ b/src/design/Dropdown/index.tsx
@@ -70,8 +70,8 @@ const DropdownMenuContent = React.forwardRef<
       className={twMergeClsx(
         "z-50 min-w-[8rem] overflow-hidden animate-in data-[side=top]:slide-in-from-bottom-2 data-[side=right]:slide-in-from-left-2 data-[side=left]:slide-in-from-right-2 data-[side=bottom]:slide-in-from-top-2",
         "rounded-md shadow-md ring-1",
-        "bg-gray-1 ring-gray-3",
-        "dark:bg-gray-dark-1 dark:ring-gray-dark-3",
+        "bg-gray-1 text-gray-11 ring-gray-3",
+        "dark:bg-gray-dark-1 dark:text-gray-dark-11 dark:ring-gray-dark-3",
         className
       )}
       {...props}

--- a/src/design/Editor/theme-dark.ts
+++ b/src/design/Editor/theme-dark.ts
@@ -18,11 +18,11 @@ export default {
       token: "string.yaml",
     },
     {
-      foreground: "7E7E7E", // grayDark.gray10
+      foreground: "ededed", // grayDark.gray12
       token: "type",
     },
     {
-      foreground: "7E7E7E", // grayDark.gray10
+      foreground: "ededed", // grayDark.gray12
       token: "string.key.json", // JSON Key
     },
     {
@@ -30,19 +30,19 @@ export default {
       token: "string.value.json", // JSON Value
     },
     {
-      foreground: "7E7E7E", // grayDark.gray10
+      foreground: "ededed", // grayDark.gray12
       token: "tag", // HTML Tag name
     },
     {
-      foreground: "7E7E7E", // gray.gray10
+      foreground: "ededed", // gray.gray12
       token: "delimiter.html", // HTML Tag <>
     },
     {
-      foreground: "7E7E7E", // grayDark.gray10
+      foreground: "ededed", // grayDark.gray12
       token: "metatag.html", // HTML Meta tag
     },
     {
-      foreground: "7E7E7E", // grayDark.gray10
+      foreground: "ededed", // grayDark.gray12
       token: "metatag.content.html", // HTML Meta tag content
     },
     {
@@ -50,7 +50,7 @@ export default {
       token: "delimiter", // HTML Meta tag content
     },
     {
-      foreground: "7E7E7E", // grayDark.gray10
+      foreground: "ededed", // grayDark.gray12
       token: "attribute.name", // HTML Attribute Name
     },
     {
@@ -86,7 +86,7 @@ export default {
       token: "keyword", // keyword in Shell script
     },
     {
-      foreground: "7E7E7E", // grayDark.gray10
+      foreground: "ededed", // grayDark.gray12
       token: "variable.predefined", // variable defined in Shell script
     },
     {
@@ -107,7 +107,7 @@ export default {
     },
   ],
   colors: {
-    "editor.foreground": "#7E7E7E", // added for HTML Tag Content gray-dark-10
+    "editor.foreground": "#ededed", // added for HTML Tag Content gray-dark-10
     "editor.background": "#000000",
     "editor.selectionBackground": "#ffffff2e", // whiteA.whiteA7
   },

--- a/src/design/Editor/theme-dark.ts
+++ b/src/design/Editor/theme-dark.ts
@@ -18,11 +18,11 @@ export default {
       token: "string.yaml",
     },
     {
-      foreground: "ededed", // grayDark.gray12
+      foreground: "a0a0a0", // grayDark.gray11
       token: "type",
     },
     {
-      foreground: "ededed", // grayDark.gray12
+      foreground: "a0a0a0", // grayDark.gray11
       token: "string.key.json", // JSON Key
     },
     {
@@ -30,19 +30,19 @@ export default {
       token: "string.value.json", // JSON Value
     },
     {
-      foreground: "ededed", // grayDark.gray12
+      foreground: "a0a0a0", // grayDark.gray11
       token: "tag", // HTML Tag name
     },
     {
-      foreground: "ededed", // gray.gray12
+      foreground: "a0a0a0", // gray.gray11
       token: "delimiter.html", // HTML Tag <>
     },
     {
-      foreground: "ededed", // grayDark.gray12
+      foreground: "a0a0a0", // grayDark.gray11
       token: "metatag.html", // HTML Meta tag
     },
     {
-      foreground: "ededed", // grayDark.gray12
+      foreground: "a0a0a0", // grayDark.gray11
       token: "metatag.content.html", // HTML Meta tag content
     },
     {
@@ -50,7 +50,7 @@ export default {
       token: "delimiter", // HTML Meta tag content
     },
     {
-      foreground: "ededed", // grayDark.gray12
+      foreground: "a0a0a0", // grayDark.gray11
       token: "attribute.name", // HTML Attribute Name
     },
     {
@@ -86,7 +86,7 @@ export default {
       token: "keyword", // keyword in Shell script
     },
     {
-      foreground: "ededed", // grayDark.gray12
+      foreground: "a0a0a0", // grayDark.gray11
       token: "variable.predefined", // variable defined in Shell script
     },
     {
@@ -107,7 +107,7 @@ export default {
     },
   ],
   colors: {
-    "editor.foreground": "#ededed", // added for HTML Tag Content gray-dark-10
+    "editor.foreground": "#a0a0a0", // added for HTML Tag Content gray-dark-10
     "editor.background": "#000000",
     "editor.selectionBackground": "#ffffff2e", // whiteA.whiteA7
   },

--- a/src/design/Editor/theme-light.ts
+++ b/src/design/Editor/theme-light.ts
@@ -18,11 +18,11 @@ export default {
       token: "string.yaml",
     },
     {
-      foreground: "171717", // gray.gray12
+      foreground: "6f6f6f", // gray.gray11
       token: "type",
     },
     {
-      foreground: "171717", // gray.gray12
+      foreground: "6f6f6f", // gray.gray11
       token: "string.key.json", // JSON Key
     },
     {
@@ -30,19 +30,19 @@ export default {
       token: "string.value.json", // JSON Value
     },
     {
-      foreground: "171717", // gray.gray12
+      foreground: "6f6f6f", // gray.gray11
       token: "tag", // HTML Tag name
     },
     {
-      foreground: "171717", // gray.gray12
+      foreground: "6f6f6f", // gray.gray11
       token: "delimiter.html", // HTML Tag <>
     },
     {
-      foreground: "171717", // gray.gray12
+      foreground: "6f6f6f", // gray.gray11
       token: "metatag.html", // HTML Meta tag
     },
     {
-      foreground: "171717", // gray.gray12
+      foreground: "6f6f6f", // gray.gray11
       token: "metatag.content.html", // HTML Meta tag content
     },
     {
@@ -50,7 +50,7 @@ export default {
       token: "delimiter", // HTML Meta tag content
     },
     {
-      foreground: "171717", // gray.gray12
+      foreground: "6f6f6f", // gray.gray11
       token: "attribute.name", // HTML Attribute Name
     },
     {
@@ -86,7 +86,7 @@ export default {
       token: "keyword", // keyword in Shell script
     },
     {
-      foreground: "171717", // gray.gray12
+      foreground: "6f6f6f", // gray.gray11
       token: "variable.predefined", // variable defined in Shell script
     },
     {
@@ -107,7 +107,7 @@ export default {
     },
   ],
   colors: {
-    "editor.foreground": "#171717", // added for HTML Tag Content
+    "editor.foreground": "#6f6f6f", // added for HTML Tag Content
     "editor.background": "#ffffff",
     "editor.selectionBackground": "#00000012", // blackA.blackA4
   },

--- a/src/design/Editor/theme-light.ts
+++ b/src/design/Editor/theme-light.ts
@@ -18,11 +18,11 @@ export default {
       token: "string.yaml",
     },
     {
-      foreground: "858585", // gray.gray10
+      foreground: "171717", // gray.gray12
       token: "type",
     },
     {
-      foreground: "858585", // gray.gray10
+      foreground: "171717", // gray.gray12
       token: "string.key.json", // JSON Key
     },
     {
@@ -30,19 +30,19 @@ export default {
       token: "string.value.json", // JSON Value
     },
     {
-      foreground: "858585", // gray.gray10
+      foreground: "171717", // gray.gray12
       token: "tag", // HTML Tag name
     },
     {
-      foreground: "858585", // gray.gray10
+      foreground: "171717", // gray.gray12
       token: "delimiter.html", // HTML Tag <>
     },
     {
-      foreground: "858585", // gray.gray10
+      foreground: "171717", // gray.gray12
       token: "metatag.html", // HTML Meta tag
     },
     {
-      foreground: "858585", // gray.gray10
+      foreground: "171717", // gray.gray12
       token: "metatag.content.html", // HTML Meta tag content
     },
     {
@@ -50,7 +50,7 @@ export default {
       token: "delimiter", // HTML Meta tag content
     },
     {
-      foreground: "858585", // gray.gray10
+      foreground: "171717", // gray.gray12
       token: "attribute.name", // HTML Attribute Name
     },
     {
@@ -86,7 +86,7 @@ export default {
       token: "keyword", // keyword in Shell script
     },
     {
-      foreground: "858585", // gray.gray10
+      foreground: "171717", // gray.gray12
       token: "variable.predefined", // variable defined in Shell script
     },
     {
@@ -107,7 +107,7 @@ export default {
     },
   ],
   colors: {
-    "editor.foreground": "#858585", // added for HTML Tag Content
+    "editor.foreground": "#171717", // added for HTML Tag Content
     "editor.background": "#ffffff",
     "editor.selectionBackground": "#00000012", // blackA.blackA4
   },

--- a/src/design/JSONschemaForm/index.tsx
+++ b/src/design/JSONschemaForm/index.tsx
@@ -177,7 +177,9 @@ const TitleFieldTemplate = (props: TitleFieldProps) => {
 const DescriptionFieldTemplate = (props: DescriptionFieldProps) => {
   const { description } = props;
   return (
-    <div className="mb-2 text-gray-8 dark:text-gray-dark-8">{description}</div>
+    <div className="mb-2 text-gray-10 dark:text-gray-dark-10">
+      {description}
+    </div>
   );
 };
 

--- a/src/design/JSONschemaForm/index.tsx
+++ b/src/design/JSONschemaForm/index.tsx
@@ -168,10 +168,7 @@ const BaseInputTemplate = (props: BaseInputTemplateProps) => {
 const TitleFieldTemplate = (props: TitleFieldProps) => {
   const { id, required, title } = props;
   return (
-    <header
-      id={id}
-      className="mb-4 font-semibold text-gray-12 dark:text-gray-dark-12"
-    >
+    <header id={id} className="mb-4 font-semibold">
       {title}
       {required && <mark>*</mark>}
     </header>

--- a/src/design/NavigationLink/index.tsx
+++ b/src/design/NavigationLink/index.tsx
@@ -5,8 +5,8 @@ import { twMergeClsx } from "~/util/helpers";
 export const createClassNames = (active: boolean, className?: string) =>
   twMergeClsx(
     active
-      ? "bg-primary-50 text-gray-12 dark:bg-primary-700 dark:text-gray-dark-12"
-      : "text-gray-11 hover:bg-gray-2 dark:text-gray-dark-11 dark:hover:bg-gray-dark-2",
+      ? "bg-primary-50 dark:bg-primary-700"
+      : "hover:bg-gray-2 dark:hover:bg-gray-dark-2",
     "[&>svg]:group group flex items-center rounded-md p-2 text-sm font-medium [&>svg]:mr-3",
     className
   );

--- a/src/design/Pagination/index.tsx
+++ b/src/design/Pagination/index.tsx
@@ -60,13 +60,12 @@ export const PaginationLink = React.forwardRef<
       {...props}
       aria-current="page"
       className={twMergeClsx(
-        "relative inline-flex cursor-pointer items-center px-4 py-2 text-sm font-semibold focus:z-20",
+        "relative inline-flex cursor-pointer items-center px-4 py-2 text-sm font-semibold ring-1 ring-inset focus:z-20 ",
         "disabled:pointer-events-none disabled:opacity-50",
-        "ring-1 ring-inset focus:outline-offset-0 focus-visible:outline-gray-9 dark:focus-visible:outline-gray-dark-9",
-        active &&
-          "z-10 bg-gray-12 text-gray-1 ring-gray-12 dark:bg-gray-dark-12 dark:text-gray-dark-1 dark:ring-gray-dark-12",
-        !active &&
-          "text-gray-12 ring-gray-7 hover:bg-gray-2 dark:text-gray-dark-12 dark:ring-gray-dark-7 dark:hover:bg-gray-dark-2"
+        "text-gray-12 ring-gray-7 focus:outline-offset-0 focus-visible:outline-gray-9",
+        "dark:text-gray-dark-12 dark:ring-gray-dark-7 dark:focus-visible:outline-gray-dark-9",
+        active && "z-10 bg-gray-3 dark:bg-gray-dark-3 ",
+        !active && "hover:bg-gray-2 dark:hover:bg-gray-dark-2"
       )}
     >
       {children}

--- a/src/design/Select/index.tsx
+++ b/src/design/Select/index.tsx
@@ -55,8 +55,8 @@ const SelectContent = React.forwardRef<
         "rounded-md ring-1",
         "ring-gray-3",
         "dark:ring-gray-dark-3",
-        "bg-gray-1",
-        "dark:bg-gray-dark-1",
+        "bg-gray-1 text-gray-11",
+        "dark:bg-gray-dark-1 dark:text-gray-dark-11",
         className
       )}
       {...props}

--- a/src/design/Tabs/index.tsx
+++ b/src/design/Tabs/index.tsx
@@ -40,9 +40,7 @@ const TabsTrigger = React.forwardRef<
         "dark:text-gray-dark-10 dark:data-[state=active]:bg-black dark:data-[state=active]:text-gray-dark-12",
       !variant &&
         "flex items-center gap-x-2 whitespace-nowrap border-b-2 border-transparent px-1 pb-4 text-sm font-medium",
-      !variant && "text-gray-11 hover:border-gray-8 hover:text-gray-12",
-      !variant &&
-        "dark:text-gray-dark-11 dark:hover:border-gray-dark-8 dark:hover:text-gray-dark-12",
+      !variant && "hover:border-current",
       !variant &&
         "data-[state=active]:border-primary-500 data-[state=active]:text-primary-500 [&>svg]:h-4 [&>svg]:w-auto",
       className

--- a/src/design/Toast/index.tsx
+++ b/src/design/Toast/index.tsx
@@ -33,9 +33,9 @@ const Toast = React.forwardRef<
     "data-[swipe=move]:transition-none group relative pointer-events-auto flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-sm transition-all data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full mt-4 data-[state=closed]:slide-out-to-right-full last:mt-0 sm:last:mt-4",
     "border-gray-3 dark:border-gray-dark-3",
     !variant &&
-      "bg-gray-4 text-gray-11 [&>button]:border-gray-11 focus:[&>button]:ring-gray-7 focus:[&>button]:ring-offset-gray-4",
+      "bg-gray-2 [&>button]:border-gray-11 focus:[&>button]:ring-gray-7 focus:[&>button]:ring-offset-gray-4",
     !variant &&
-      "dark:bg-gray-dark-4 dark:text-gray-dark-11 dark:[&>button]:border-gray-dark-11 dark:focus:[&>button]:ring-gray-dark-7 dark:focus:[&>button]:ring-offset-gray-dark-4",
+      "dark:bg-gray-dark-2 dark:[&>button]:border-gray-dark-11 dark:focus:[&>button]:ring-gray-dark-7 dark:focus:[&>button]:ring-offset-gray-dark-4",
     variant === "error" &&
       "bg-danger-4 text-danger-11 [&>button]:border-danger-11 focus:[&>button]:ring-danger-7 focus:[&>button]:ring-offset-danger-4",
     variant === "error" &&

--- a/src/design/Tooltip/index.tsx
+++ b/src/design/Tooltip/index.tsx
@@ -19,8 +19,8 @@ const TooltipContent = React.forwardRef<
     sideOffset={sideOffset}
     className={twMergeClsx(
       "z-50 overflow-hidden rounded-md border px-3 py-1.5 text-sm  shadow-md animate-in fade-in-50 data-[side=bottom]:slide-in-from-top-1 data-[side=top]:slide-in-from-bottom-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 ",
-      "border-gray-2 bg-gray-1 text-gray-10",
-      "dark:border-gray-dark-2 dark:bg-gray-dark-1 dark:text-gray-10",
+      "border-gray-2 bg-gray-1 text-gray-11",
+      "dark:border-gray-dark-2 dark:bg-gray-dark-1 dark:text-gray-11",
       className
     )}
     {...props}

--- a/src/pages/namespace/Explorer/Tree/index.tsx
+++ b/src/pages/namespace/Explorer/Tree/index.tsx
@@ -114,7 +114,7 @@ const ExplorerPage: FC = () => {
                             >
                               {file.name}
                             </Link>
-                            <span className="text-gray-8 dark:text-gray-dark-8">
+                            <span className="text-gray-9 dark:text-gray-dark-9">
                               {moment(file.updatedAt).fromNow()}
                             </span>
                           </div>

--- a/src/pages/namespace/Explorer/Workflow/Active/WorkflowEditor.tsx
+++ b/src/pages/namespace/Explorer/Workflow/Active/WorkflowEditor.tsx
@@ -64,7 +64,7 @@ const WorkflowEditor: FC<{
 
   return (
     <div className="relative flex grow flex-col space-y-4 p-5">
-      <h3 className="flex items-center gap-x-2 font-bold text-gray-10 dark:text-gray-dark-10">
+      <h3 className="flex items-center gap-x-2 font-bold">
         <Tag className="h-5" />
         {t("pages.explorer.workflow.headline")}
       </h3>

--- a/src/pages/namespace/Explorer/Workflow/Revisions/Detail/index.tsx
+++ b/src/pages/namespace/Explorer/Workflow/Revisions/Detail/index.tsx
@@ -39,7 +39,7 @@ const WorkflowRevisionsPage = () => {
     <div className="flex grow flex-col space-y-4">
       <div className="flex gap-x-4">
         <h3
-          className="group flex grow items-center gap-x-2 font-bold text-gray-10 dark:text-gray-dark-10"
+          className="group flex grow items-center gap-x-2 font-bold"
           data-testid="revisions-detail-title"
         >
           <Icon aria-hidden="true" className="h-5" />

--- a/src/pages/namespace/Explorer/Workflow/Revisions/Overview/List/index.tsx
+++ b/src/pages/namespace/Explorer/Workflow/Revisions/Overview/List/index.tsx
@@ -57,7 +57,7 @@ const RevisionsList: FC = () => {
 
   return (
     <>
-      <h3 className="flex items-center gap-x-2 font-bold text-gray-10 dark:text-gray-dark-10">
+      <h3 className="flex items-center gap-x-2 font-bold">
         <GitMerge className="h-5" />
         {t("pages.explorer.tree.workflow.revisions.overview.list.title")}
       </h3>

--- a/src/pages/namespace/Explorer/Workflow/Revisions/Overview/List/index.tsx
+++ b/src/pages/namespace/Explorer/Workflow/Revisions/Overview/List/index.tsx
@@ -56,7 +56,7 @@ const RevisionsList: FC = () => {
   if (!isFetched) return null;
 
   return (
-    <>
+    <section className="flex flex-col gap-4">
       <h3 className="flex items-center gap-x-2 font-bold">
         <GitMerge className="h-5" />
         {t("pages.explorer.tree.workflow.revisions.overview.list.title")}
@@ -131,7 +131,7 @@ const RevisionsList: FC = () => {
           </DialogContent>
         </Dialog>
       </Card>
-    </>
+    </section>
   );
 };
 

--- a/src/pages/namespace/Explorer/Workflow/Revisions/Overview/TrafficShaping/index.tsx
+++ b/src/pages/namespace/Explorer/Workflow/Revisions/Overview/TrafficShaping/index.tsx
@@ -71,7 +71,7 @@ const TrafficShaping: FC = () => {
   if (!isFetched) return null;
 
   return (
-    <>
+    <section className="flex flex-col gap-4">
       <h3 className="flex items-center gap-x-2 font-bold">
         <Network className="h-5" />
         {t(
@@ -161,7 +161,7 @@ const TrafficShaping: FC = () => {
           )}
         </div>
       </Card>
-    </>
+    </section>
   );
 };
 

--- a/src/pages/namespace/Explorer/Workflow/Revisions/Overview/TrafficShaping/index.tsx
+++ b/src/pages/namespace/Explorer/Workflow/Revisions/Overview/TrafficShaping/index.tsx
@@ -72,7 +72,7 @@ const TrafficShaping: FC = () => {
 
   return (
     <>
-      <h3 className="flex items-center gap-x-2 font-bold text-gray-10 dark:text-gray-dark-10">
+      <h3 className="flex items-center gap-x-2 font-bold">
         <Network className="h-5" />
         {t(
           "pages.explorer.tree.workflow.revisions.overview.trafficShaping.title"

--- a/src/pages/namespace/Explorer/Workflow/Revisions/Overview/index.tsx
+++ b/src/pages/namespace/Explorer/Workflow/Revisions/Overview/index.tsx
@@ -2,10 +2,10 @@ import List from "./List";
 import TrafficShaping from "./TrafficShaping";
 
 const RevisionsOverviewPage = () => (
-  <>
+  <div className="flex flex-col space-y-10">
     <TrafficShaping />
     <List />
-  </>
+  </div>
 );
 
 export default RevisionsOverviewPage;

--- a/src/pages/namespace/Instances/List/index.tsx
+++ b/src/pages/namespace/Instances/List/index.tsx
@@ -31,7 +31,7 @@ const InstancesListPage = () => {
 
   return (
     <div className="flex grow flex-col gap-y-4 p-5">
-      <h3 className="flex items-center gap-x-2 font-bold text-gray-10 dark:text-gray-dark-10">
+      <h3 className="flex items-center gap-x-2 font-bold">
         <Boxes className="h-5" />
         {t("pages.instances.list.title")}
       </h3>

--- a/src/pages/namespace/Settings/Broadcasts/index.tsx
+++ b/src/pages/namespace/Settings/Broadcasts/index.tsx
@@ -43,7 +43,7 @@ const Broadcasts: FC = () => {
   return (
     <>
       <div className="mb-3 flex flex-row justify-between">
-        <h3 className="flex items-center gap-x-2 pb-2 pt-1 font-bold text-gray-10 dark:text-gray-dark-10">
+        <h3 className="flex items-center gap-x-2 pb-2 pt-1 font-bold">
           <Radio className="h-5" />
           {t("pages.settings.broadcasts.title")}
         </h3>

--- a/src/pages/namespace/Settings/Registries/index.tsx
+++ b/src/pages/namespace/Settings/Registries/index.tsx
@@ -42,7 +42,7 @@ const RegistriesList: FC = () => {
   return (
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
       <div className="mb-3 flex flex-row justify-between">
-        <h3 className="flex items-center gap-x-2 pb-2 pt-1 font-bold text-gray-10 dark:text-gray-dark-10">
+        <h3 className="flex items-center gap-x-2 pb-2 pt-1 font-bold">
           <Container className="h-5" />
           {t("pages.settings.registries.list.title")}
         </h3>

--- a/src/pages/namespace/Settings/Secrets/index.tsx
+++ b/src/pages/namespace/Settings/Secrets/index.tsx
@@ -42,7 +42,7 @@ const SecretsList: FC = () => {
   return (
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
       <div className="mb-3 flex flex-row justify-between">
-        <h3 className="flex items-center gap-x-2 pb-2 pt-1 font-bold text-gray-10 dark:text-gray-dark-10">
+        <h3 className="flex items-center gap-x-2 pb-2 pt-1 font-bold">
           <SquareAsterisk className="h-5" />
           {t("pages.settings.secrets.list.title")}
         </h3>

--- a/src/pages/namespace/Settings/Variables/index.tsx
+++ b/src/pages/namespace/Settings/Variables/index.tsx
@@ -44,7 +44,7 @@ const VariablesList: FC = () => {
   return (
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
       <div className="mb-3 flex flex-row justify-between">
-        <h3 className="flex items-center gap-x-2 pb-2 pt-1 font-bold text-gray-10 dark:text-gray-dark-10">
+        <h3 className="flex items-center gap-x-2 pb-2 pt-1 font-bold">
           <Braces className="h-5" />
           {t("pages.settings.variables.list.title")}
         </h3>

--- a/src/pages/namespace/Settings/index.tsx
+++ b/src/pages/namespace/Settings/index.tsx
@@ -34,7 +34,7 @@ const SettingsPage: FC = () => {
   }
 
   return (
-    <div className="flex flex-col space-y-6 p-10">
+    <div className="flex flex-col space-y-10 p-5">
       <section data-testid="secrets-section">
         <SecretsList />
       </section>


### PR DESCRIPTION
This PR is best reviewed with the [old](https://direktiv-ui-refs-heads-feature-redesign.direktiv.dev/stefan/explorer/tree) and [new](https://direktiv-ui-refs-heads-stefankracht-dir-683-design-tweaking.direktiv.dev/stefan/explorer/tree) version opened in two browser tabs. The goal is to make the base color much darker as it was before. The old version has very low contrast and looks very pale. The new version is still not perfect, but I think a good iteration in the right direction.

[Changing the base color](https://github.com/direktiv/direktiv-ui/pull/418/commits/4ed72a68dc647d9505c62a07517c815429fa14c7) forced me to change a lot of colors in other files to either also change the color there or keep the appearance as it was before and not inherit that change (e.g. I wanted to keep all dropdown like elements as they were).

I also used the chance to fix some other smaller, general design issues.

## General
**old light mode**
![Bildschirm­foto 2023-07-10 um 13 48 37](https://github.com/direktiv/direktiv-ui/assets/121789579/95437a65-10de-40d4-a6a9-6a664024187b)
**new light mode**
![Bildschirm­foto 2023-07-10 um 13 49 05](https://github.com/direktiv/direktiv-ui/assets/121789579/b3b0dcad-fb8a-497a-8d22-8208214ad0a1)
**old dark mode**
![Bildschirm­foto 2023-07-10 um 13 50 56](https://github.com/direktiv/direktiv-ui/assets/121789579/dd118c32-8581-4660-9d7a-7905c9ef85d3)
**new dark mode**
![Bildschirm­foto 2023-07-10 um 13 50 58](https://github.com/direktiv/direktiv-ui/assets/121789579/a044e124-02f4-4416-a083-47ed01b7a0dc)

## Section Spacing

The "sections" (card with a headline) where inconsistent in padding to the main container at some places and I felt they all needed a bit more space to keep them apart from each other and easy spot which headline belongs to which card

**old settings page**
![Bildschirm­foto 2023-07-10 um 13 57 11](https://github.com/direktiv/direktiv-ui/assets/121789579/100c0615-7667-4d43-9a48-26c44adec62e)
**new settings page**
![Bildschirm­foto 2023-07-10 um 13 57 19](https://github.com/direktiv/direktiv-ui/assets/121789579/350d18e1-4638-4005-a07c-299e6ac4c15f)
**old revisions list page**
![Bildschirm­foto 2023-07-10 um 13 58 00](https://github.com/direktiv/direktiv-ui/assets/121789579/79e8022f-8d24-4668-bf37-31cd9f6d6541)
**new revisions list page**
![Bildschirm­foto 2023-07-10 um 13 58 13](https://github.com/direktiv/direktiv-ui/assets/121789579/9b0aaeee-1bcd-4e22-a32e-ead93d471d5a)

## Pagination

Goal: the background color of the active pagination page had the appearance of a button and has attracted too much attention

**old light mode**
![1](https://github.com/direktiv/direktiv-ui/assets/121789579/bb7a20d2-0d5e-416a-aeef-8b76b9a8709b)
new light mode
![2](https://github.com/direktiv/direktiv-ui/assets/121789579/9c20363a-2d30-4af1-a1a9-28e9918fed9e)
old dark mode
![3](https://github.com/direktiv/direktiv-ui/assets/121789579/d9844842-f94d-4e88-a243-eefe057caf94)
new dark mode
![4](https://github.com/direktiv/direktiv-ui/assets/121789579/b7402294-5824-4f05-a379-a2db2f48fd23)