### PR TITLE
Use global teardown to delete e2e test  namespaces

### DIFF
--- a/e2e/explorer/index.spec.ts
+++ b/e2e/explorer/index.spec.ts
@@ -2,7 +2,6 @@ import {
   checkIfNamespaceExists,
   createNamespace,
   createNamespaceName,
-  deleteNamespace,
 } from "../utils/namespace";
 import {
   checkIfNodeExists,
@@ -18,7 +17,6 @@ test.beforeEach(async () => {
 });
 
 test.afterEach(async () => {
-  await deleteNamespace(namespace);
   namespace = "";
 });
 
@@ -96,9 +94,6 @@ test("it is possible to create a namespace via breadcrumbs", async ({
   // make sure namespace exists in backend
   const namespaceCreated = await checkIfNamespaceExists(newNamespace);
   await expect(namespaceCreated).toBeTruthy;
-
-  // cleanup
-  await deleteNamespace(newNamespace);
 });
 
 test("it is possible to create a folder", async ({ page }) => {

--- a/e2e/explorer/workflow/active.spec.ts
+++ b/e2e/explorer/workflow/active.spec.ts
@@ -4,8 +4,8 @@ import {
   actionRevertRevision,
   actionWaitForSuccessToast,
 } from "./utils";
-import { createNamespace, deleteNamespace } from "../../utils/namespace";
 
+import { createNamespace } from "../../utils/namespace";
 import { createWorkflow } from "../../utils/node";
 import { faker } from "@faker-js/faker";
 
@@ -19,7 +19,6 @@ test.beforeEach(async () => {
 });
 
 test.afterEach(async () => {
-  await deleteNamespace(namespace);
   namespace = "";
 });
 

--- a/e2e/explorer/workflow/diagramEditor.spec.ts
+++ b/e2e/explorer/workflow/diagramEditor.spec.ts
@@ -1,7 +1,7 @@
 import { Page, expect, test } from "@playwright/test";
-import { createNamespace, deleteNamespace } from "../../utils/namespace";
 
 import { consumeEvent as consumeEventWorkflow } from "~/pages/namespace/Explorer/Tree/NewWorkflow/templates";
+import { createNamespace } from "../../utils/namespace";
 import { createRevision } from "~/api/tree/mutate/createRevision";
 import { createWorkflow } from "~/api/tree/mutate/createWorkflow";
 import { faker } from "@faker-js/faker";
@@ -44,7 +44,6 @@ test.beforeEach(async () => {
 });
 
 test.afterEach(async () => {
-  await deleteNamespace(namespace);
   namespace = "";
 });
 

--- a/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
+++ b/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
@@ -1,7 +1,7 @@
-import { createNamespace, deleteNamespace } from "../../../utils/namespace";
 import { expect, test } from "@playwright/test";
 
 import { noop as basicWorkflow } from "~/pages/namespace/Explorer/Tree/NewWorkflow/templates";
+import { createNamespace } from "../../../utils/namespace";
 import { createWorkflow } from "~/api/tree/mutate/createWorkflow";
 import { createWorkflowWithThreeRevisions } from "../../../utils/revisions";
 import { faker } from "@faker-js/faker";
@@ -14,7 +14,6 @@ test.beforeEach(async () => {
 });
 
 test.afterEach(async () => {
-  await deleteNamespace(namespace);
   namespace = "";
 });
 

--- a/e2e/explorer/workflow/revisions/revisionsList.spec.ts
+++ b/e2e/explorer/workflow/revisions/revisionsList.spec.ts
@@ -1,7 +1,7 @@
 import { Page, expect, test } from "@playwright/test";
 import { actionDeleteRevision, actionWaitForSuccessToast } from "../utils";
-import { createNamespace, deleteNamespace } from "../../../utils/namespace";
 
+import { createNamespace } from "../../../utils/namespace";
 import { createWorkflow } from "../../../utils/node";
 import { createWorkflowWithThreeRevisions } from "../../../utils/revisions";
 import { faker } from "@faker-js/faker";
@@ -13,7 +13,6 @@ test.beforeEach(async () => {
 });
 
 test.afterEach(async () => {
-  await deleteNamespace(namespace);
   namespace = "";
 });
 

--- a/e2e/explorer/workflow/revisions/trafficShaping.spec.ts
+++ b/e2e/explorer/workflow/revisions/trafficShaping.spec.ts
@@ -1,7 +1,7 @@
-import { createNamespace, deleteNamespace } from "../../../utils/namespace";
 import { expect, test } from "@playwright/test";
 
 import { noop as basicWorkflow } from "~/pages/namespace/Explorer/Tree/NewWorkflow/templates";
+import { createNamespace } from "../../../utils/namespace";
 import { createWorkflow } from "~/api/tree/mutate/createWorkflow";
 import { createWorkflowWithThreeRevisions } from "../../../utils/revisions";
 import { faker } from "@faker-js/faker";
@@ -13,7 +13,6 @@ test.beforeEach(async () => {
 });
 
 test.afterEach(async () => {
-  await deleteNamespace(namespace);
   namespace = "";
 });
 

--- a/e2e/explorer/workflow/run.spec.ts
+++ b/e2e/explorer/workflow/run.spec.ts
@@ -1,8 +1,8 @@
-import { createNamespace, deleteNamespace } from "../../utils/namespace";
 import { expect, test } from "@playwright/test";
 import { jsonSchemaFormWorkflow, jsonSchemaWithRequiredEnum } from "./utils";
 
 import { noop as basicWorkflow } from "~/pages/namespace/Explorer/Tree/NewWorkflow/templates";
+import { createNamespace } from "../../utils/namespace";
 import { createWorkflow } from "~/api/tree/mutate/createWorkflow";
 import { faker } from "@faker-js/faker";
 import { getInput } from "~/api/instances/query/input";
@@ -14,7 +14,6 @@ test.beforeEach(async () => {
 });
 
 test.afterEach(async () => {
-  await deleteNamespace(namespace);
   namespace = "";
 });
 

--- a/e2e/globalSetup.ts
+++ b/e2e/globalSetup.ts
@@ -1,0 +1,16 @@
+import { cleanupNamespaces } from "./utils/namespace";
+import { faker } from "@faker-js/faker";
+
+const globalSetup = () => {
+  const testRunId = faker.git.shortSha();
+  process.env.TEST_RUN_ID = testRunId;
+
+  return async () => {
+    if (!testRunId) {
+      throw new Error("process.env.TEST_RUN_ID is not defined");
+    }
+    await cleanupNamespaces(testRunId);
+  };
+};
+
+export default globalSetup;

--- a/e2e/instances/list/index.spec.ts
+++ b/e2e/instances/list/index.spec.ts
@@ -1,4 +1,3 @@
-import { createNamespace, deleteNamespace } from "../../utils/namespace";
 import { expect, test } from "@playwright/test";
 import {
   parentWorkflow as parentWorkflowContent,
@@ -6,6 +5,7 @@ import {
   workflowThatFails as workflowThatFailsContent,
 } from "./utils";
 
+import { createNamespace } from "../../utils/namespace";
 import { createWorkflow } from "~/api/tree/mutate/createWorkflow";
 import { faker } from "@faker-js/faker";
 import { getInstances } from "~/api/instances/query/get";
@@ -41,7 +41,6 @@ test.beforeEach(async () => {
 });
 
 test.afterEach(async () => {
-  await deleteNamespace(namespace);
   namespace = "";
 });
 

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,5 +1,6 @@
-import { createNamespaceName, deleteNamespace } from "./utils/namespace";
 import { expect, test } from "@playwright/test";
+
+import { createNamespaceName } from "./utils/namespace";
 
 test("if no namespaces exist, it renders the onboarding page", async ({
   page,
@@ -57,7 +58,4 @@ test("if no namespaces exist, it renders the onboarding page", async ({
     page.getByTestId("breadcrumb-namespace"),
     "the breadcrumb shows the new namespace"
   ).toHaveText(namespace);
-
-  // cleanup
-  await deleteNamespace(namespace);
 });

--- a/e2e/settings/index.spec.ts
+++ b/e2e/settings/index.spec.ts
@@ -1,10 +1,10 @@
-import { createNamespace, deleteNamespace } from "../utils/namespace";
 import { expect, test } from "@playwright/test";
 
 import { BroadcastsSchemaKeys } from "~/api/broadcasts/schema";
 import { MimeTypeSchema } from "~/pages/namespace/Settings/Variables/MimeTypeSelect";
 import { actionWaitForSuccessToast } from "../explorer/workflow/utils";
 import { createBroadcasts } from "../utils/broadcasts";
+import { createNamespace } from "../utils/namespace";
 import { createRegistries } from "../utils/registries";
 import { createSecrets } from "../utils/secrets";
 import { createVariables } from "../utils/variables";
@@ -20,7 +20,6 @@ test.beforeEach(async () => {
 });
 
 test.afterEach(async () => {
-  await deleteNamespace(namespace);
   namespace = "";
 });
 

--- a/e2e/utils/namespace.ts
+++ b/e2e/utils/namespace.ts
@@ -2,8 +2,10 @@ import { NamespaceListSchemaType } from "~/api/namespaces/schema";
 import { faker } from "@faker-js/faker";
 
 const apiUrl = process.env.VITE_DEV_API_DOMAIN;
+const testRunId = process.env.TEST_RUN_ID;
 
-export const createNamespaceName = () => `playwright-${faker.git.shortSha()}`;
+export const createNamespaceName = () =>
+  `pw-${testRunId}-${faker.git.shortSha()}`;
 
 export const createNamespace = () =>
   new Promise<string>((resolve, reject) => {
@@ -17,16 +19,17 @@ export const createNamespace = () =>
     });
   });
 
-export const deleteNamespace = (namespace: string) =>
-  new Promise<void>((resolve, reject) => {
-    fetch(`${apiUrl}/api/namespaces/${namespace}?recursive=true`, {
-      method: "DELETE",
-    }).then((response) => {
-      response.ok
-        ? resolve()
-        : reject(`deleting namespace failed with code ${response.status}`);
-    });
-  });
+// not currently used, rely on cleanupNamespaces during global teardown instead
+// export const deleteNamespace = (namespace: string) =>
+//   new Promise<void>((resolve, reject) => {
+//     fetch(`${apiUrl}/api/namespaces/${namespace}?recursive=true`, {
+//       method: "DELETE",
+//     }).then((response) => {
+//       response.ok
+//         ? resolve()
+//         : reject(`deleting namespace failed with code ${response.status}`);
+//     });
+//   });
 
 export const checkIfNamespaceExists = async (namespace: string) => {
   const response = await fetch(`${apiUrl}/api/namespaces`);
@@ -41,16 +44,15 @@ export const checkIfNamespaceExists = async (namespace: string) => {
   return !!namespaceInResponse;
 };
 
-// Not intended for regular use. Namespaces should be cleaned up after every test.
-// E.g., see the beforeEach and afterEach implementation in e2e/explorer.spec.ts.
-// If you have spammed namespaces while writing tests, call this temporarily:
-// await cleanupNamespace();
-export const cleanupNamespaces = async () => {
+// This is used in global teardown to delete all namespaces created during
+// the current test run. This avoids a negative impact of the server load
+// caused by deleting namespaces on consecutive tests.
+export const cleanupNamespaces = async (testRunId: string) => {
   const response = await fetch(`${apiUrl}/api/namespaces`);
   const namespaces = await response
     .json()
     .then((json: NamespaceListSchemaType) =>
-      json.results.filter((ns) => ns.name.includes("playwright"))
+      json.results.filter((ns) => ns.name.includes(`pw-${testRunId}`))
     );
   const requests = namespaces.map((ns) =>
     fetch(`${apiUrl}/api/namespaces/${ns.name}?recursive=true`, {
@@ -58,5 +60,5 @@ export const cleanupNamespaces = async () => {
     })
   );
 
-  return Promise.all(requests);
+  return await Promise.all(requests);
 };

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -74,6 +74,8 @@ export default defineConfig({
     // },
   ],
 
+  globalSetup: "./e2e/globalSetup",
+
   /* Run your local dev server before starting the tests */
   webServer: {
     command: `yarn run vite --port ${process.env.VITE_E2E_UI_PORT}`,


### PR DESCRIPTION
## Description

This removes the `deleteNamespace` from individual tests (and the afterEach hook respectively), and instead deletes all namespaces created during the test run in a [global teardown](https://playwright.dev/docs/test-global-setup-teardown) method.

Since deleting namespaces is expensive, postponing it until all tests have finished should improve the speed / stability of the tests.

The first jobs still had flaky tests (mainly concerned with the workflow editor and diagram?), but seemed to be a bit faster than previous jobs.

I'll leave this on "draft" for now until I have time to compare it to other test runs, and maybe retrigger it a few times to get a better impression of how it affects the tests.