### PR TITLE
DIR-471 Add mirror form to namespace create dialog

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -310,6 +310,10 @@
       "createBtn": "Create",
       "nameAlreadyExists": "The name already exists",
       "cancelBtn": "Cancel",
+      "tab": {
+        "namespace": "Namespace",
+        "mirror": "Mirror"
+      },
       "authType": {
         "none": "none",
         "ssh": "SSH",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -307,20 +307,42 @@
     },
     "namespaceCreate": {
       "title": "Create a new namespace",
-      "placeholder": "new-namespace-name",
       "createBtn": "Create",
-      "nameLabel": "Name",
       "nameAlreadyExists": "The name already exists",
       "cancelBtn": "Cancel",
-      "refLabel": "Ref",
-      "urlLabel": "Url",
-      "passphrase": "Passphrase",
-      "publicKey": "Public Key",
-      "privateKey": "Private Key",
       "authType": {
         "none": "none",
         "ssh": "SSH",
         "token": "token"
+      },
+      "placeholder": {
+        "name": "new-namespace-name",
+        "ref": "branch or commit hash",
+        "httpUrl": "https://example.com/direktiv/repo.git",
+        "gitUrl": "git@example.com/direktiv/repo.git",
+        "passphrase": "Passphrase (optional)",
+        "publicKey": "Public Key (required)",
+        "privateKey": "Private Key (required)",
+        "token": "token",
+        "authType": "Select authentication method"
+      },
+      "label": {
+        "name": "Name",
+        "ref": "Ref",
+        "url": "Url",
+        "passphrase": "Passphrase",
+        "publicKey": "Public key",
+        "privateKey": "Private key",
+        "token": "token",
+        "authType": "Auth type"
+      },
+      "tooltip": {
+        "url": "URL to repository. If auth method is SSH, a git url must be used, e.g. 'git@github.com:direktiv/apps-svc.git'. All other auth methods must use HTTP/S urls.",
+        "ref": "Repository reference to sync from. For example this could be a commit hash ('b139f0e') or branch ('main').",
+        "token": "Personal access token (for authentication with a HTTP/S url).",
+        "passphrase": "Passphrase to decrypt keys (optional).",
+        "privateKey": "Private SSH key used for authentication via git@ url.",
+        "publicKey": "Public SSH key used for authenticating via git@ url."
       }
     },
     "button": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -309,9 +309,19 @@
       "title": "Create a new namespace",
       "placeholder": "new-namespace-name",
       "createBtn": "Create",
-      "namespaceLabel": "Namespace",
+      "nameLabel": "Name",
       "nameAlreadyExists": "The name already exists",
-      "cancelBtn": "Cancel"
+      "cancelBtn": "Cancel",
+      "refLabel": "Ref",
+      "urlLabel": "Url",
+      "passphrase": "Passphrase",
+      "publicKey": "Public Key",
+      "privateKey": "Private Key",
+      "authType": {
+        "none": "none",
+        "ssh": "SSH",
+        "token": "token"
+      }
     },
     "button": {
       "label": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -333,7 +333,7 @@
         "passphrase": "Passphrase",
         "publicKey": "Public key",
         "privateKey": "Private key",
-        "token": "token",
+        "token": "Token",
         "authType": "Auth type"
       },
       "tooltip": {

--- a/src/api/namespaces/__tests__/schema.test.ts
+++ b/src/api/namespaces/__tests__/schema.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+
+import { gitUrlSchema } from "../schema";
+
+describe("Git url validation", () => {
+  test("it validates a valid url", async () => {
+    expect(
+      gitUrlSchema.safeParse("git@examle.com:user/repository.git").success
+    ).toBeTruthy();
+  });
+
+  test("it does not allow a http url", () => {
+    expect(
+      gitUrlSchema.safeParse("http://examle.com/user/repository.git").success
+    ).toBeFalsy();
+  });
+
+  test("it does not allow a https url", () => {
+    expect(
+      gitUrlSchema.safeParse("https://examle.com/user/repository.git").success
+    ).toBeFalsy();
+  });
+
+  test("it does not allow a slash after the domain name", () => {
+    expect(
+      gitUrlSchema.safeParse("git@examle.com/user/repository.git").success
+    ).toBeFalsy();
+  });
+
+  test("it requires the url to start with git@", () => {
+    expect(
+      gitUrlSchema.safeParse("examle.com:user/repository.git").success
+    ).toBeFalsy();
+  });
+});

--- a/src/api/namespaces/mutate/createNamespace.ts
+++ b/src/api/namespaces/mutate/createNamespace.ts
@@ -1,7 +1,7 @@
+import type { MirrorSchemaType, NamespaceListSchemaType } from "../schema";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { NamespaceCreatedSchema } from "../schema";
-import type { NamespaceListSchemaType } from "../schema";
 import { apiFactory } from "~/api/apiFactory";
 import { namespaceKeys } from "..";
 import { sortByName } from "~/api/tree/utils";
@@ -10,7 +10,8 @@ import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 
 const createNamespace = apiFactory({
-  url: ({ name }: { name: string }) => `/api/namespaces/${name}`,
+  url: ({ name }: { name: string; mirror?: MirrorSchemaType }) =>
+    `/api/namespaces/${name}`,
   method: "PUT",
   schema: NamespaceCreatedSchema,
 });
@@ -26,12 +27,19 @@ export const useCreateNamespace = ({
   const { t } = useTranslation();
 
   return useMutation({
-    mutationFn: ({ name }: { name: string }) =>
+    mutationFn: ({
+      name,
+      mirror,
+    }: {
+      name: string;
+      mirror?: MirrorSchemaType;
+    }) =>
       createNamespace({
         apiKey: apiKey ?? undefined,
         urlParams: {
           name,
         },
+        payload: mirror,
       }),
     onSuccess(data, variables) {
       queryClient.setQueryData<NamespaceListSchemaType>(

--- a/src/api/namespaces/mutate/createNamespace.ts
+++ b/src/api/namespaces/mutate/createNamespace.ts
@@ -1,4 +1,4 @@
-import type { MirrorSchemaType, NamespaceListSchemaType } from "../schema";
+import type { MirrorFormSchemaType, NamespaceListSchemaType } from "../schema";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { NamespaceCreatedSchema } from "../schema";
@@ -10,7 +10,7 @@ import { useToast } from "~/design/Toast";
 import { useTranslation } from "react-i18next";
 
 const createNamespace = apiFactory({
-  url: ({ name }: { name: string; mirror?: MirrorSchemaType }) =>
+  url: ({ name }: { name: string; mirror?: MirrorFormSchemaType }) =>
     `/api/namespaces/${name}`,
   method: "PUT",
   schema: NamespaceCreatedSchema,
@@ -32,7 +32,7 @@ export const useCreateNamespace = ({
       mirror,
     }: {
       name: string;
-      mirror?: MirrorSchemaType;
+      mirror?: MirrorFormSchemaType;
     }) =>
       createNamespace({
         apiKey: apiKey ?? undefined,

--- a/src/api/namespaces/schema.ts
+++ b/src/api/namespaces/schema.ts
@@ -42,7 +42,9 @@ export const MirrorTokenFormSchema = z.object({
 });
 
 export const MirrorSshFormSchema = z.object({
-  url: gitUrlSchema,
+  url: gitUrlSchema.nonempty({
+    message: "format must be git@host:path when using SSH",
+  }),
   ref: z.string().nonempty(),
   passphrase: z.string().optional(),
   privateKey: z.string().nonempty({ message: "Required when using SSH" }),

--- a/src/api/namespaces/schema.ts
+++ b/src/api/namespaces/schema.ts
@@ -17,4 +17,15 @@ export const NamespaceCreatedSchema = z.object({
   namespace: NamespaceSchema,
 });
 
+// note: in the current API implementation, a mirror is created
+// by creating a namespace with this in the payload.
+export const MirrorSchema = z.object({
+  passphrase: z.string().optional(),
+  privateKey: z.string().optional(),
+  publicKey: z.string().optional(),
+  ref: z.string().nonempty(),
+  url: z.string().url().nonempty(),
+});
+
 export type NamespaceListSchemaType = z.infer<typeof NamespaceListSchema>;
+export type MirrorSchemaType = z.infer<typeof MirrorSchema>;

--- a/src/api/namespaces/schema.ts
+++ b/src/api/namespaces/schema.ts
@@ -17,7 +17,7 @@ export const NamespaceCreatedSchema = z.object({
 
 // Regex for input validation. This isn't perfect but should be good enough for
 // a start. Matches git@hostname:path, where path isn't very restrictive.
-const gitUrlSchema = z
+export const gitUrlSchema = z
   .string()
   .regex(/^([a-zA-Z0-9.\-_]+@[a-zA-Z0-9.\-_]+:[a-zA-Z0-9.\-_/]+)*$/, {
     message: "format must be git@host:path when using SSH",

--- a/src/api/namespaces/schema.ts
+++ b/src/api/namespaces/schema.ts
@@ -17,15 +17,44 @@ export const NamespaceCreatedSchema = z.object({
   namespace: NamespaceSchema,
 });
 
+// Regex for input validation. This isn't perfect but should be good enough for
+// a start. Matches git@hostname:path, where path isn't very restrictive.
+const gitUrlSchema = z
+  .string()
+  .regex(/^([a-zA-Z0-9.\-_]+@[a-zA-Z0-9.\-_]+:[a-zA-Z0-9.\-_/]+)*$/, {
+    message: "format must be git@host:path when using SSH",
+  });
+
 // note: in the current API implementation, a mirror is created
 // by creating a namespace with this in the payload.
-export const MirrorSchema = z.object({
-  passphrase: z.string().optional(),
-  privateKey: z.string().optional(),
-  publicKey: z.string().optional(),
-  ref: z.string().nonempty(),
+export const MirrorPublicFormSchema = z.object({
   url: z.string().url().nonempty(),
+  ref: z.string().nonempty(),
 });
 
+// When Token auth is used, token is submitted as "passphrase"
+export const MirrorTokenFormSchema = z.object({
+  url: z.string().url().nonempty(),
+  ref: z.string().nonempty(),
+  passphrase: z
+    .string()
+    .nonempty({ message: "Required when using token auth" }),
+});
+
+export const MirrorSshFormSchema = z.object({
+  url: gitUrlSchema,
+  ref: z.string().nonempty(),
+  passphrase: z.string().optional(),
+  privateKey: z.string().nonempty({ message: "Required when using SSH" }),
+  publicKey: z.string().nonempty({ message: "Required when using SSH" }),
+});
+
+export const MirrorFormSchema = MirrorPublicFormSchema.or(
+  MirrorTokenFormSchema
+).or(MirrorSshFormSchema);
+
 export type NamespaceListSchemaType = z.infer<typeof NamespaceListSchema>;
-export type MirrorSchemaType = z.infer<typeof MirrorSchema>;
+export type MirrorPublicFormSchemaType = z.infer<typeof MirrorPublicFormSchema>;
+export type MirrorTokenFormSchemaType = z.infer<typeof MirrorTokenFormSchema>;
+export type MirrorSshFormSchemaType = z.infer<typeof MirrorSshFormSchema>;
+export type MirrorFormSchemaType = z.infer<typeof MirrorFormSchema>;

--- a/src/api/tree/schema.ts
+++ b/src/api/tree/schema.ts
@@ -7,11 +7,11 @@ const NodeSchema = z.object({
   name: z.string(),
   path: z.string(),
   parent: z.string(),
-  type: z.enum(["directory", "workflow"]),
+  type: z.enum(["directory", "workflow", "file"]),
   attributes: z.array(z.string()), // must be more specified
   oid: z.string(),
   readOnly: z.boolean(),
-  expandedType: z.enum(["directory", "workflow", "git"]),
+  expandedType: z.enum(["directory", "workflow", "file", "git"]),
 });
 
 const RevisionSchema = z.object({

--- a/src/componentsNext/NamespaceCreate/InfoTooltip.tsx
+++ b/src/componentsNext/NamespaceCreate/InfoTooltip.tsx
@@ -1,0 +1,22 @@
+import { FC, PropsWithChildren } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "~/design/Tooltip";
+
+import { Info } from "lucide-react";
+
+const InfoTooltip: FC<PropsWithChildren> = ({ children }) => (
+  <TooltipProvider>
+    <Tooltip delayDuration={100}>
+      <TooltipTrigger type="button">
+        <Info size={16} className="ml-2 inline align-middle text-gray-11" />
+      </TooltipTrigger>
+      <TooltipContent className="max-w-md text-left">{children}</TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);
+
+export default InfoTooltip;

--- a/src/componentsNext/NamespaceCreate/InfoTooltip.tsx
+++ b/src/componentsNext/NamespaceCreate/InfoTooltip.tsx
@@ -12,7 +12,7 @@ const InfoTooltip: FC<PropsWithChildren> = ({ children }) => (
   <TooltipProvider>
     <Tooltip delayDuration={100}>
       <TooltipTrigger type="button">
-        <Info size={16} className="ml-2 text-gray-11" />
+        <Info size={16} className="mx-2 text-gray-11" />
       </TooltipTrigger>
       <TooltipContent className="max-w-md text-left">{children}</TooltipContent>
     </Tooltip>

--- a/src/componentsNext/NamespaceCreate/InfoTooltip.tsx
+++ b/src/componentsNext/NamespaceCreate/InfoTooltip.tsx
@@ -12,7 +12,7 @@ const InfoTooltip: FC<PropsWithChildren> = ({ children }) => (
   <TooltipProvider>
     <Tooltip delayDuration={100}>
       <TooltipTrigger type="button">
-        <Info size={16} className="ml-2 inline align-middle text-gray-11" />
+        <Info size={16} className="ml-2 text-gray-11" />
       </TooltipTrigger>
       <TooltipContent className="max-w-md text-left">{children}</TooltipContent>
     </Tooltip>

--- a/src/componentsNext/NamespaceCreate/index.tsx
+++ b/src/componentsNext/NamespaceCreate/index.tsx
@@ -28,6 +28,7 @@ import FormErrors from "~/componentsNext/FormErrors";
 import InfoTooltip from "./InfoTooltip";
 import Input from "~/design/Input";
 import { InputWithButton } from "~/design/InputWithButton";
+import { Textarea } from "~/design/TextArea";
 import { fileNameSchema } from "~/api/tree/schema";
 import { pages } from "~/util/router/pages";
 import { useCreateNamespace } from "~/api/namespaces/mutate/createNamespace";
@@ -257,7 +258,7 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
                     {t("components.namespaceCreate.label.token")}
                   </label>
                   <InputWithButton>
-                    <Input
+                    <Textarea
                       id="token"
                       data-testid="new-namespace-token"
                       placeholder={t(
@@ -276,13 +277,13 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
                 <>
                   <fieldset className="flex items-center gap-5">
                     <label
-                      className="w-[144px] overflow-hidden text-right text-[14px]"
+                      className="w-[90px] overflow-hidden text-right text-[14px]"
                       htmlFor="passphrase"
                     >
                       {t("components.namespaceCreate.label.passphrase")}
                     </label>
                     <InputWithButton>
-                      <Input
+                      <Textarea
                         id="passphrase"
                         data-testid="new-namespace-passphrase"
                         placeholder={t(
@@ -297,13 +298,13 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
                   </fieldset>
                   <fieldset className="flex items-center gap-5">
                     <label
-                      className="w-[144px] overflow-hidden text-right text-[14px]"
+                      className="w-[90px] overflow-hidden text-right text-[14px]"
                       htmlFor="public-key"
                     >
                       {t("components.namespaceCreate.label.publicKey")}
                     </label>
                     <InputWithButton>
-                      <Input
+                      <Textarea
                         id="public-key"
                         data-testid="new-namespace-pubkey"
                         placeholder={t(
@@ -319,13 +320,13 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
 
                   <fieldset className="flex items-center gap-5">
                     <label
-                      className="w-[144px] overflow-hidden text-right text-[14px]"
+                      className="w-[90px] overflow-hidden text-right text-[14px]"
                       htmlFor="private-key"
                     >
                       {t("components.namespaceCreate.label.privateKey")}
                     </label>
                     <InputWithButton>
-                      <Input
+                      <Textarea
                         id="private-key"
                         data-testid="new-namespace-privkey"
                         placeholder={t(

--- a/src/componentsNext/NamespaceCreate/index.tsx
+++ b/src/componentsNext/NamespaceCreate/index.tsx
@@ -5,7 +5,16 @@ import {
   DialogTitle,
 } from "~/design/Dialog";
 import { Home, PlusCircle } from "lucide-react";
+import { MirrorSchema, MirrorSchemaType } from "~/api/namespaces/schema";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/design/Select";
 import { SubmitHandler, useForm } from "react-hook-form";
+import { Tabs, TabsList, TabsTrigger } from "~/design/Tabs";
 
 import Button from "~/design/Button";
 import FormErrors from "~/componentsNext/FormErrors";
@@ -16,37 +25,45 @@ import { useCreateNamespace } from "~/api/namespaces/mutate/createNamespace";
 import { useListNamespaces } from "~/api/namespaces/query/get";
 import { useNamespaceActions } from "~/util/store/namespace";
 import { useNavigate } from "react-router-dom";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 type FormInput = {
   name: string;
-};
+} & MirrorSchemaType;
+
+const mirrorAuthTypes = ["none", "ssh", "token"] as const;
 
 const NamespaceCreate = ({ close }: { close: () => void }) => {
   const { t } = useTranslation();
+  const [isMirror, setIsMirror] = useState<boolean>(false);
+  const [authType, setAuthType] = useState<string>("none");
   const { data } = useListNamespaces();
   const { setNamespace } = useNamespaceActions();
+  const navigate = useNavigate();
+
   const existingNamespaces = data?.results.map((n) => n.name) || [];
 
-  const navigate = useNavigate();
+  const nameSchema = fileNameSchema.and(
+    z.string().refine((name) => !existingNamespaces.some((n) => n === name), {
+      message: t("components.namespaceCreate.nameAlreadyExists"),
+    })
+  );
+
+  const simpleNamespaceResolver = zodResolver(z.object({ name: nameSchema }));
+
+  const mirrorResolver = zodResolver(
+    MirrorSchema.and(z.object({ name: nameSchema }))
+  );
+
   const {
     register,
     handleSubmit,
     formState: { isDirty, errors, isValid, isSubmitted },
   } = useForm<FormInput>({
-    resolver: zodResolver(
-      z.object({
-        name: fileNameSchema.and(
-          z
-            .string()
-            .refine((name) => !existingNamespaces.some((n) => n === name), {
-              message: t("components.namespaceCreate.nameAlreadyExists"),
-            })
-        ),
-      })
-    ),
+    resolver: isMirror ? mirrorResolver : simpleNamespaceResolver,
   });
 
   const { mutate: createNamespace, isLoading } = useCreateNamespace({
@@ -61,8 +78,18 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
     },
   });
 
-  const onSubmit: SubmitHandler<FormInput> = ({ name }) => {
-    createNamespace({ name });
+  const onSubmit: SubmitHandler<FormInput> = ({
+    name,
+    ref,
+    url,
+    passphrase,
+    publicKey,
+    privateKey,
+  }) => {
+    createNamespace({
+      name,
+      mirror: { ref, url, passphrase, publicKey, privateKey },
+    });
   };
 
   // you can not submit if the form has not changed or if there are any errors and
@@ -78,12 +105,27 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
         </DialogTitle>
       </DialogHeader>
 
+      <Tabs className="w-[400px]" defaultValue="namespace">
+        <TabsList>
+          <TabsTrigger value="namespace" onClick={() => setIsMirror(false)}>
+            Namespace
+          </TabsTrigger>
+          <TabsTrigger value="mirror" onClick={() => setIsMirror(true)}>
+            Mirror
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+
       <div className="my-3">
         <FormErrors errors={errors} className="mb-5" />
-        <form id={formId} onSubmit={handleSubmit(onSubmit)}>
+        <form
+          id={formId}
+          onSubmit={handleSubmit(onSubmit)}
+          className="flex flex-col gap-y-5"
+        >
           <fieldset className="flex items-center gap-5">
             <label className="w-[90px] text-right text-[14px]" htmlFor="name">
-              {t("components.namespaceCreate.namespaceLabel")}
+              {t("components.namespaceCreate.nameLabel")}
             </label>
             <Input
               id="name"
@@ -92,8 +134,111 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
               {...register("name")}
             />
           </fieldset>
+
+          {isMirror && (
+            <>
+              <fieldset className="flex items-center gap-5">
+                <label
+                  className="w-[90px] text-right text-[14px]"
+                  htmlFor="name"
+                >
+                  {t("components.namespaceCreate.urlLabel")}
+                </label>
+                <Input
+                  id="name"
+                  data-testid="new-namespace-name"
+                  placeholder={t("components.namespaceCreate.placeholder")}
+                  {...register("url")}
+                />
+              </fieldset>
+
+              <fieldset className="flex items-center gap-5">
+                <label
+                  className="w-[90px] text-right text-[14px]"
+                  htmlFor="name"
+                >
+                  {t("components.namespaceCreate.refLabel")}
+                </label>
+                <Input
+                  id="name"
+                  data-testid="new-namespace-name"
+                  placeholder={t("components.namespaceCreate.placeholder")}
+                  {...register("ref")}
+                />
+              </fieldset>
+
+              <Select value={authType} onValueChange={setAuthType}>
+                <SelectTrigger variant="outline" className="ml-[90px]">
+                  <SelectValue placeholder="Select Auth Method" />
+                </SelectTrigger>
+                <SelectContent>
+                  {mirrorAuthTypes.map((option) => (
+                    <SelectItem
+                      key={option}
+                      value={option}
+                      onClick={() => setAuthType(option)}
+                    >
+                      {t(`components.namespaceCreate.authType.${option}`)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {(authType === "token" || authType == "ssh") && (
+                <fieldset className="flex items-center gap-5">
+                  <label
+                    className="w-[90px] text-right text-[14px]"
+                    htmlFor="name"
+                  >
+                    {t("components.namespaceCreate.passphrase")}
+                  </label>
+                  <Input
+                    id="name"
+                    data-testid="new-namespace-name"
+                    placeholder={t("components.namespaceCreate.placeholder")}
+                    {...register("passphrase")}
+                  />
+                </fieldset>
+              )}
+
+              {authType === "ssh" && (
+                <>
+                  <fieldset className="flex items-center gap-5">
+                    <label
+                      className="w-[90px] text-right text-[14px]"
+                      htmlFor="name"
+                    >
+                      {t("components.namespaceCreate.publicKey")}
+                    </label>
+                    <Input
+                      id="name"
+                      data-testid="new-namespace-name"
+                      placeholder={t("components.namespaceCreate.placeholder")}
+                      {...register("publicKey")}
+                    />
+                  </fieldset>
+
+                  <fieldset className="flex items-center gap-5">
+                    <label
+                      className="w-[90px] text-right text-[14px]"
+                      htmlFor="name"
+                    >
+                      {t("components.namespaceCreate.privateKey")}
+                    </label>
+                    <Input
+                      id="name"
+                      data-testid="new-namespace-name"
+                      placeholder={t("components.namespaceCreate.placeholder")}
+                      {...register("privateKey")}
+                    />
+                  </fieldset>
+                </>
+              )}
+            </>
+          )}
         </form>
       </div>
+
       <DialogFooter>
         <DialogClose asChild>
           <Button variant="ghost">

--- a/src/componentsNext/NamespaceCreate/index.tsx
+++ b/src/componentsNext/NamespaceCreate/index.tsx
@@ -27,7 +27,7 @@ import Button from "~/design/Button";
 import FormErrors from "~/componentsNext/FormErrors";
 import InfoTooltip from "./InfoTooltip";
 import Input from "~/design/Input";
-import { Textarea } from "~/design/TextArea";
+import { InputWithButton } from "~/design/InputWithButton";
 import { fileNameSchema } from "~/api/tree/schema";
 import { pages } from "~/util/router/pages";
 import { useCreateNamespace } from "~/api/namespaces/mutate/createNamespace";
@@ -176,20 +176,22 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
                   htmlFor="url"
                 >
                   {t("components.namespaceCreate.label.url")}
+                </label>
+                <InputWithButton>
+                  <Input
+                    id="url"
+                    data-testid="new-namespace-url"
+                    placeholder={t(
+                      authType === "ssh"
+                        ? "components.namespaceCreate.placeholder.gitUrl"
+                        : "components.namespaceCreate.placeholder.httpUrl"
+                    )}
+                    {...register("url")}
+                  />
                   <InfoTooltip>
                     {t("components.namespaceCreate.tooltip.url")}
                   </InfoTooltip>
-                </label>
-                <Input
-                  id="url"
-                  data-testid="new-namespace-url"
-                  placeholder={t(
-                    authType === "ssh"
-                      ? "components.namespaceCreate.placeholder.gitUrl"
-                      : "components.namespaceCreate.placeholder.httpUrl"
-                  )}
-                  {...register("url")}
-                />
+                </InputWithButton>
               </fieldset>
 
               <fieldset className="flex items-center gap-5">
@@ -198,16 +200,20 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
                   htmlFor="ref"
                 >
                   {t("components.namespaceCreate.label.ref")}
+                </label>
+                <InputWithButton>
+                  <Input
+                    id="ref"
+                    data-testid="new-namespace-ref"
+                    placeholder={t(
+                      "components.namespaceCreate.placeholder.ref"
+                    )}
+                    {...register("ref")}
+                  />
                   <InfoTooltip>
                     {t("components.namespaceCreate.tooltip.ref")}
                   </InfoTooltip>
-                </label>
-                <Input
-                  id="ref"
-                  data-testid="new-namespace-ref"
-                  placeholder={t("components.namespaceCreate.placeholder.ref")}
-                  {...register("ref")}
-                />
+                </InputWithButton>
               </fieldset>
 
               <fieldset className="flex items-center gap-5">
@@ -249,18 +255,20 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
                     htmlFor="token"
                   >
                     {t("components.namespaceCreate.label.token")}
+                  </label>
+                  <InputWithButton>
+                    <Input
+                      id="token"
+                      data-testid="new-namespace-token"
+                      placeholder={t(
+                        "components.namespaceCreate.placeholder.token"
+                      )}
+                      {...register("passphrase")}
+                    />
                     <InfoTooltip>
                       {t("components.namespaceCreate.tooltip.token")}
                     </InfoTooltip>
-                  </label>
-                  <Textarea
-                    id="token"
-                    data-testid="new-namespace-token"
-                    placeholder={t(
-                      "components.namespaceCreate.placeholder.token"
-                    )}
-                    {...register("passphrase")}
-                  />
+                  </InputWithButton>
                 </fieldset>
               )}
 
@@ -272,18 +280,20 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
                       htmlFor="passphrase"
                     >
                       {t("components.namespaceCreate.label.passphrase")}
+                    </label>
+                    <InputWithButton>
+                      <Input
+                        id="passphrase"
+                        data-testid="new-namespace-passphrase"
+                        placeholder={t(
+                          "components.namespaceCreate.placeholder.passphrase"
+                        )}
+                        {...register("passphrase")}
+                      />
                       <InfoTooltip>
                         {t("components.namespaceCreate.tooltip.passphrase")}
                       </InfoTooltip>
-                    </label>
-                    <Input
-                      id="passphrase"
-                      data-testid="new-namespace-passphrase"
-                      placeholder={t(
-                        "components.namespaceCreate.placeholder.passphrase"
-                      )}
-                      {...register("passphrase")}
-                    />
+                    </InputWithButton>
                   </fieldset>
                   <fieldset className="flex items-center gap-5">
                     <label
@@ -291,18 +301,20 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
                       htmlFor="public-key"
                     >
                       {t("components.namespaceCreate.label.publicKey")}
+                    </label>
+                    <InputWithButton>
+                      <Input
+                        id="public-key"
+                        data-testid="new-namespace-pubkey"
+                        placeholder={t(
+                          "components.namespaceCreate.placeholder.publicKey"
+                        )}
+                        {...register("publicKey")}
+                      />
                       <InfoTooltip>
                         {t("components.namespaceCreate.tooltip.publicKey")}
                       </InfoTooltip>
-                    </label>
-                    <Input
-                      id="public-key"
-                      data-testid="new-namespace-pubkey"
-                      placeholder={t(
-                        "components.namespaceCreate.placeholder.publicKey"
-                      )}
-                      {...register("publicKey")}
-                    />
+                    </InputWithButton>
                   </fieldset>
 
                   <fieldset className="flex items-center gap-5">
@@ -311,18 +323,20 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
                       htmlFor="private-key"
                     >
                       {t("components.namespaceCreate.label.privateKey")}
+                    </label>
+                    <InputWithButton>
+                      <Input
+                        id="private-key"
+                        data-testid="new-namespace-privkey"
+                        placeholder={t(
+                          "components.namespaceCreate.placeholder.privateKey"
+                        )}
+                        {...register("privateKey")}
+                      />
                       <InfoTooltip>
                         {t("components.namespaceCreate.tooltip.privateKey")}
                       </InfoTooltip>
-                    </label>
-                    <Input
-                      id="private-key"
-                      data-testid="new-namespace-privkey"
-                      placeholder={t(
-                        "components.namespaceCreate.placeholder.privateKey"
-                      )}
-                      {...register("privateKey")}
-                    />
+                    </InputWithButton>
                   </fieldset>
                 </>
               )}

--- a/src/componentsNext/NamespaceCreate/index.tsx
+++ b/src/componentsNext/NamespaceCreate/index.tsx
@@ -128,7 +128,7 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
         </DialogTitle>
       </DialogHeader>
 
-      <Tabs className="mt-2 w-[400px]" defaultValue="namespace">
+      <Tabs className="mt-2 sm:w-[400px]" defaultValue="namespace">
         <TabsList variant="boxed">
           <TabsTrigger
             variant="boxed"

--- a/src/componentsNext/NamespaceCreate/index.tsx
+++ b/src/componentsNext/NamespaceCreate/index.tsx
@@ -22,6 +22,7 @@ import {
 } from "~/design/Select";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { Tabs, TabsList, TabsTrigger } from "~/design/Tabs";
+import { useEffect, useState } from "react";
 
 import Button from "~/design/Button";
 import FormErrors from "~/componentsNext/FormErrors";
@@ -35,7 +36,6 @@ import { useCreateNamespace } from "~/api/namespaces/mutate/createNamespace";
 import { useListNamespaces } from "~/api/namespaces/query/get";
 import { useNamespaceActions } from "~/util/store/namespace";
 import { useNavigate } from "react-router-dom";
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -84,6 +84,7 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
   const {
     register,
     handleSubmit,
+    trigger,
     formState: { isDirty, errors, isValid, isSubmitted },
   } = useForm<FormInput>({
     resolver: getResolver(isMirror, authType),
@@ -118,6 +119,14 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
   // you can not submit if the form has not changed or if there are any errors and
   // you have already submitted the form (errors will first show up after submit)
   const disableSubmit = !isDirty || (isSubmitted && !isValid);
+
+  // if the form has errors, we need to re-validate when isMirror or authType
+  // has been changed, after useForm has updated the resolver.
+  useEffect(() => {
+    if (isSubmitted && !isValid) {
+      trigger();
+    }
+  }, [isMirror, authType, isSubmitted, isValid, trigger]);
 
   const formId = `new-namespace`;
   return (

--- a/src/componentsNext/NamespaceCreate/index.tsx
+++ b/src/componentsNext/NamespaceCreate/index.tsx
@@ -18,6 +18,7 @@ import { Tabs, TabsList, TabsTrigger } from "~/design/Tabs";
 
 import Button from "~/design/Button";
 import FormErrors from "~/componentsNext/FormErrors";
+import InfoTooltip from "./InfoTooltip";
 import Input from "~/design/Input";
 import { fileNameSchema } from "~/api/tree/schema";
 import { pages } from "~/util/router/pages";
@@ -124,13 +125,16 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
           className="flex flex-col gap-y-5"
         >
           <fieldset className="flex items-center gap-5">
-            <label className="w-[90px] text-right text-[14px]" htmlFor="name">
-              {t("components.namespaceCreate.nameLabel")}
+            <label
+              className="w-[90px] overflow-hidden text-right text-[14px]"
+              htmlFor="name"
+            >
+              {t("components.namespaceCreate.label.name")}
             </label>
             <Input
               id="name"
               data-testid="new-namespace-name"
-              placeholder={t("components.namespaceCreate.placeholder")}
+              placeholder={t("components.namespaceCreate.placeholder.name")}
               {...register("name")}
             />
           </fieldset>
@@ -139,63 +143,90 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
             <>
               <fieldset className="flex items-center gap-5">
                 <label
-                  className="w-[90px] text-right text-[14px]"
-                  htmlFor="name"
+                  className="w-[90px] flex-row overflow-hidden text-right text-[14px]"
+                  htmlFor="url"
                 >
-                  {t("components.namespaceCreate.urlLabel")}
+                  {t("components.namespaceCreate.label.url")}
+                  <InfoTooltip>
+                    {t("components.namespaceCreate.tooltip.url")}
+                  </InfoTooltip>
                 </label>
                 <Input
-                  id="name"
-                  data-testid="new-namespace-name"
-                  placeholder={t("components.namespaceCreate.placeholder")}
+                  id="url"
+                  data-testid="new-namespace-url"
+                  placeholder={t(
+                    authType === "ssh"
+                      ? "components.namespaceCreate.placeholder.gitUrl"
+                      : "components.namespaceCreate.placeholder.httpUrl"
+                  )}
                   {...register("url")}
                 />
               </fieldset>
 
               <fieldset className="flex items-center gap-5">
                 <label
-                  className="w-[90px] text-right text-[14px]"
-                  htmlFor="name"
+                  className="w-[90px] overflow-hidden text-right text-[14px]"
+                  htmlFor="ref"
                 >
-                  {t("components.namespaceCreate.refLabel")}
+                  {t("components.namespaceCreate.label.ref")}
+                  <InfoTooltip>
+                    {t("components.namespaceCreate.tooltip.ref")}
+                  </InfoTooltip>
                 </label>
                 <Input
-                  id="name"
-                  data-testid="new-namespace-name"
-                  placeholder={t("components.namespaceCreate.placeholder")}
+                  id="ref"
+                  data-testid="new-namespace-ref"
+                  placeholder={t("components.namespaceCreate.placeholder.ref")}
                   {...register("ref")}
                 />
               </fieldset>
 
-              <Select value={authType} onValueChange={setAuthType}>
-                <SelectTrigger variant="outline" className="ml-[90px]">
-                  <SelectValue placeholder="Select Auth Method" />
-                </SelectTrigger>
-                <SelectContent>
-                  {mirrorAuthTypes.map((option) => (
-                    <SelectItem
-                      key={option}
-                      value={option}
-                      onClick={() => setAuthType(option)}
-                    >
-                      {t(`components.namespaceCreate.authType.${option}`)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <fieldset className="flex items-center gap-5">
+                <label
+                  className="w-[90px] overflow-hidden text-right text-[14px]"
+                  htmlFor="ref"
+                >
+                  {t("components.namespaceCreate.label.authType")}
+                </label>
+                <Select value={authType} onValueChange={setAuthType}>
+                  <SelectTrigger variant="outline" className="w-full">
+                    <SelectValue
+                      placeholder={t(
+                        "components.namespaceCreate.placeholder.authType"
+                      )}
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {mirrorAuthTypes.map((option) => (
+                      <SelectItem
+                        key={option}
+                        value={option}
+                        onClick={() => setAuthType(option)}
+                      >
+                        {t(`components.namespaceCreate.authType.${option}`)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </fieldset>
 
-              {(authType === "token" || authType == "ssh") && (
+              {authType === "token" && (
                 <fieldset className="flex items-center gap-5">
                   <label
-                    className="w-[90px] text-right text-[14px]"
-                    htmlFor="name"
+                    className="w-[90px] overflow-hidden text-right text-[14px]"
+                    htmlFor="token"
                   >
-                    {t("components.namespaceCreate.passphrase")}
+                    {t("components.namespaceCreate.label.token")}
+                    <InfoTooltip>
+                      {t("components.namespaceCreate.tooltip.token")}
+                    </InfoTooltip>
                   </label>
                   <Input
-                    id="name"
-                    data-testid="new-namespace-name"
-                    placeholder={t("components.namespaceCreate.placeholder")}
+                    id="token"
+                    data-testid="new-namespace-token"
+                    placeholder={t(
+                      "components.namespaceCreate.placeholder.token"
+                    )}
                     {...register("passphrase")}
                   />
                 </fieldset>
@@ -205,30 +236,59 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
                 <>
                   <fieldset className="flex items-center gap-5">
                     <label
-                      className="w-[90px] text-right text-[14px]"
-                      htmlFor="name"
+                      className="w-[144px] overflow-hidden text-right text-[14px]"
+                      htmlFor="passphrase"
                     >
-                      {t("components.namespaceCreate.publicKey")}
+                      {t("components.namespaceCreate.label.passphrase")}
+                      <InfoTooltip>
+                        {t("components.namespaceCreate.tooltip.passphrase")}
+                      </InfoTooltip>
                     </label>
                     <Input
-                      id="name"
-                      data-testid="new-namespace-name"
-                      placeholder={t("components.namespaceCreate.placeholder")}
+                      id="passphrase"
+                      data-testid="new-namespace-passphrase"
+                      placeholder={t(
+                        "components.namespaceCreate.placeholder.passphrase"
+                      )}
+                      {...register("passphrase")}
+                    />
+                  </fieldset>
+                  <fieldset className="flex items-center gap-5">
+                    <label
+                      className="w-[144px] overflow-hidden text-right text-[14px]"
+                      htmlFor="public-key"
+                    >
+                      {t("components.namespaceCreate.label.publicKey")}
+                      <InfoTooltip>
+                        {t("components.namespaceCreate.tooltip.publicKey")}
+                      </InfoTooltip>
+                    </label>
+                    <Input
+                      id="public-key"
+                      data-testid="new-namespace-pubkey"
+                      placeholder={t(
+                        "components.namespaceCreate.placeholder.publicKey"
+                      )}
                       {...register("publicKey")}
                     />
                   </fieldset>
 
                   <fieldset className="flex items-center gap-5">
                     <label
-                      className="w-[90px] text-right text-[14px]"
-                      htmlFor="name"
+                      className="w-[144px] overflow-hidden text-right text-[14px]"
+                      htmlFor="private-key"
                     >
-                      {t("components.namespaceCreate.privateKey")}
+                      {t("components.namespaceCreate.label.privateKey")}
+                      <InfoTooltip>
+                        {t("components.namespaceCreate.tooltip.privateKey")}
+                      </InfoTooltip>
                     </label>
                     <Input
-                      id="name"
-                      data-testid="new-namespace-name"
-                      placeholder={t("components.namespaceCreate.placeholder")}
+                      id="private-key"
+                      data-testid="new-namespace-privkey"
+                      placeholder={t(
+                        "components.namespaceCreate.placeholder.privateKey"
+                      )}
                       {...register("privateKey")}
                     />
                   </fieldset>

--- a/src/componentsNext/NamespaceCreate/index.tsx
+++ b/src/componentsNext/NamespaceCreate/index.tsx
@@ -20,6 +20,7 @@ import Button from "~/design/Button";
 import FormErrors from "~/componentsNext/FormErrors";
 import InfoTooltip from "./InfoTooltip";
 import Input from "~/design/Input";
+import { Textarea } from "~/design/TextArea";
 import { fileNameSchema } from "~/api/tree/schema";
 import { pages } from "~/util/router/pages";
 import { useCreateNamespace } from "~/api/namespaces/mutate/createNamespace";
@@ -107,11 +108,19 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
       </DialogHeader>
 
       <Tabs className="w-[400px]" defaultValue="namespace">
-        <TabsList>
-          <TabsTrigger value="namespace" onClick={() => setIsMirror(false)}>
+        <TabsList variant="boxed">
+          <TabsTrigger
+            variant="boxed"
+            value="namespace"
+            onClick={() => setIsMirror(false)}
+          >
             Namespace
           </TabsTrigger>
-          <TabsTrigger value="mirror" onClick={() => setIsMirror(true)}>
+          <TabsTrigger
+            variant="boxed"
+            value="mirror"
+            onClick={() => setIsMirror(true)}
+          >
             Mirror
           </TabsTrigger>
         </TabsList>
@@ -221,7 +230,7 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
                       {t("components.namespaceCreate.tooltip.token")}
                     </InfoTooltip>
                   </label>
-                  <Input
+                  <Textarea
                     id="token"
                     data-testid="new-namespace-token"
                     placeholder={t(

--- a/src/componentsNext/NamespaceCreate/index.tsx
+++ b/src/componentsNext/NamespaceCreate/index.tsx
@@ -128,7 +128,7 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
         </DialogTitle>
       </DialogHeader>
 
-      <Tabs className="w-[400px]" defaultValue="namespace">
+      <Tabs className="mt-2 w-[400px]" defaultValue="namespace">
         <TabsList variant="boxed">
           <TabsTrigger
             variant="boxed"
@@ -147,7 +147,7 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
         </TabsList>
       </Tabs>
 
-      <div className="my-3">
+      <div className="mt-1 mb-3">
         <FormErrors errors={errors} className="mb-5" />
         <form
           id={formId}

--- a/src/componentsNext/NamespaceCreate/index.tsx
+++ b/src/componentsNext/NamespaceCreate/index.tsx
@@ -165,7 +165,7 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
         >
           <fieldset className="flex items-center gap-5">
             <label
-              className="w-[90px] overflow-hidden text-right text-[14px]"
+              className="w-[112px] overflow-hidden text-right text-[14px]"
               htmlFor="name"
             >
               {t("components.namespaceCreate.label.name")}
@@ -182,7 +182,7 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
             <>
               <fieldset className="flex items-center gap-5">
                 <label
-                  className="w-[90px] flex-row overflow-hidden text-right text-[14px]"
+                  className="w-[112px] flex-row overflow-hidden text-right text-[14px]"
                   htmlFor="url"
                 >
                   {t("components.namespaceCreate.label.url")}
@@ -206,7 +206,7 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
 
               <fieldset className="flex items-center gap-5">
                 <label
-                  className="w-[90px] overflow-hidden text-right text-[14px]"
+                  className="w-[112px] overflow-hidden text-right text-[14px]"
                   htmlFor="ref"
                 >
                   {t("components.namespaceCreate.label.ref")}
@@ -228,7 +228,7 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
 
               <fieldset className="flex items-center gap-5">
                 <label
-                  className="w-[90px] overflow-hidden text-right text-[14px]"
+                  className="w-[112px] overflow-hidden text-right text-[14px]"
                   htmlFor="ref"
                 >
                   {t("components.namespaceCreate.label.authType")}
@@ -261,7 +261,7 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
               {authType === "token" && (
                 <fieldset className="flex items-center gap-5">
                   <label
-                    className="w-[90px] overflow-hidden text-right text-[14px]"
+                    className="w-[112px] overflow-hidden text-right text-[14px]"
                     htmlFor="token"
                   >
                     {t("components.namespaceCreate.label.token")}
@@ -286,7 +286,7 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
                 <>
                   <fieldset className="flex items-center gap-5">
                     <label
-                      className="w-[90px] overflow-hidden text-right text-[14px]"
+                      className="w-[112px] overflow-hidden text-right text-[14px]"
                       htmlFor="passphrase"
                     >
                       {t("components.namespaceCreate.label.passphrase")}
@@ -307,7 +307,7 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
                   </fieldset>
                   <fieldset className="flex items-center gap-5">
                     <label
-                      className="w-[90px] overflow-hidden text-right text-[14px]"
+                      className="w-[112px] overflow-hidden text-right text-[14px]"
                       htmlFor="public-key"
                     >
                       {t("components.namespaceCreate.label.publicKey")}
@@ -329,7 +329,7 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
 
                   <fieldset className="flex items-center gap-5">
                     <label
-                      className="w-[90px] overflow-hidden text-right text-[14px]"
+                      className="w-[112px] overflow-hidden text-right text-[14px]"
                       htmlFor="private-key"
                     >
                       {t("components.namespaceCreate.label.privateKey")}

--- a/src/componentsNext/NamespaceCreate/index.tsx
+++ b/src/componentsNext/NamespaceCreate/index.tsx
@@ -114,14 +114,14 @@ const NamespaceCreate = ({ close }: { close: () => void }) => {
             value="namespace"
             onClick={() => setIsMirror(false)}
           >
-            Namespace
+            {t("components.namespaceCreate.tab.namespace")}
           </TabsTrigger>
           <TabsTrigger
             variant="boxed"
             value="mirror"
             onClick={() => setIsMirror(true)}
           >
-            Mirror
+            {t("components.namespaceCreate.tab.mirror")}
           </TabsTrigger>
         </TabsList>
       </Tabs>

--- a/src/design/InputWithButton/index.tsx
+++ b/src/design/InputWithButton/index.tsx
@@ -14,7 +14,7 @@ export const InputWithButton: React.FC<HTMLAttributes<HTMLDivElement>> = ({
     <div
       {...props}
       className={twMergeClsx(
-        "relative flex w-full items-end p-0 [&_input]:pr-10",
+        "&_input]:pr-10 relative flex w-full items-end",
         className
       )}
     >

--- a/src/design/InputWithButton/index.tsx
+++ b/src/design/InputWithButton/index.tsx
@@ -14,7 +14,7 @@ export const InputWithButton: React.FC<HTMLAttributes<HTMLDivElement>> = ({
     <div
       {...props}
       className={twMergeClsx(
-        "relative flex items-end p-1 [&_input]:pr-10",
+        "relative flex w-full items-end p-0 [&_input]:pr-10",
         className
       )}
     >


### PR DESCRIPTION
## Description

* Added new tab to namespace create dialog that makes it possible to create mirror.
* Depending on the namespace type (mirror or simple namespace), and mirror auth method (none, ssh, token), the validation schema changes so only valid data can be submitted. 
* Updated the NodeSchema to be compatible with latest API changes (without this, rendering of non-workflow files in a mirror can fail). There is still work to be done on rendering non-workflow files correctly, but that should be in the scope of another ticket (DIR-475).

## Notes for testing and review

* Aaron has already created an InfoTooltip component under `src/componentsNext/NamespaceCreate/InfoTooltip.tsx` in https://github.com/direktiv/direktiv-ui/pull/428/, I think I will use that one when it has been merged and remove the one under `src/componentsNext/NamespaceCreate/InfoTooltip.tsx`.
* We briefly discussed whether a hint should be given when a url is entered and the required format changes between ssh/https. As soon as validation has been triggered once, this is now reflected in the validation errors that are updated when changing criteria. However, I could not conceptualize a good way to check the url field separately before the whole form is validated (mostly in terms of what would make sense UX wise. useForm does offer methods to trigger validation for individual fields, but I think it would be confusing to show only a single error when other fields are theoretically invalid as well, but just haven't been checked yet).
* With partially complete / valid inputs, switch between mirror and non-mirror and different auth types. As soon as validation has been triggered once (by submitting with an invalid form), the errors rendered should always appear/disappear according to the different validation criteria. 
* I have tested token based authentication with a private repository at https://github.com/xbow/direktiv-mirror.git. I will share the access token created for that repository on request.
* I have not tested ssh authentication with a real key pair, but the new UI should behave exactly like the old UI. Maybe it is good enough to ask the back-end colleagues to test that everything works correctly after merging.
* The back-end accepts invalid data without returning an error. For example. It will create a new namespace even when a wrong SSH key pair is entered (it will just not be populated with any files, I suspect that syncing just fails silently?). This is something we should improve in a later iteration (make the API more verbose regarding errors).

## Update 20230804

In 7a057d2dc5fa930e1a57432dcaf361fdac0b0718, I applied css fixes that Aaron added in https://github.com/direktiv/direktiv-ui/pull/428 to this branch. I think that other PR will need some discussion how Storybook should be organized, which I would like to postpone until we have met our milestones for the release; but we should already use these small css fixes now. 