### PR TITLE
[DIR-716] remove revision from the instance list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@
 # e2e tests will also run against this API
 VITE_DEV_API_DOMAIN="http://api.for.development.com"
 
+# If the above API requires an authentication token, the following must be set
+# in order to run e2e tests against that API. For normal use, this is not relevant,
+# as the API token will be entered via the UI and saved in local storage.
+# VITE_E2E_API_TOKEN="abcde"
+
 # only neccesary when building for production, will be displayed underneath the login
 VITE_APP_VERSION=""
 
@@ -20,5 +25,5 @@ VITE_LEGACY_DESIGN="TRUE" # true or TRUE will evaluate to true, everything else 
 VITE_E2E_UI_HOST="http://localhost"
 VITE_E2E_UI_PORT="3333"
 
-# enable reat query dev tools (only for dev server, they will always be excluded in production builds)
+# enable react query dev tools (only for dev server, they will always be excluded in production builds)
 VITE_RQ_DEV_TOOLS="FALSE" # true or TRUE will evaluate to true, everything else will be false

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,7 @@
 name: Playwright Tests
 on:
-  workflow_dispatch:
+  push:
+    branches: [ "feature/redesign", "**/dir-**" ]
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,7 +1,6 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ "feature/redesign", "**/dir-**" ]
+  workflow_dispatch:
 jobs:
   test:
     timeout-minutes: 60

--- a/e2e/explorer/workflow/active.spec.ts
+++ b/e2e/explorer/workflow/active.spec.ts
@@ -17,7 +17,7 @@ test.beforeEach(async () => {
   namespace = await createNamespace();
   workflow = await createWorkflow(
     namespace,
-    faker.internet.domainName() + ".yaml"
+    faker.internet.domainWord() + ".yaml"
   );
 });
 
@@ -41,15 +41,19 @@ const testSaveWorkflow = async (page: Page) => {
   const saveButton = page.getByTestId("workflow-editor-btn-save");
   await saveButton.click();
 
-  // save button should be disabled/enabled while/after the api call
-  await expect(
-    saveButton,
-    "save button should be disabled during the api call"
-  ).toBeDisabled();
-  await expect(
-    saveButton,
-    "save button should be enabled after the api call"
-  ).toBeEnabled();
+  // Commented out since this is not a critical step, but maybe we can enable
+  // it again at some point after learning more about the following problem:
+  // These steps fail locally, but work with a remote API. They works locally
+  // with throttling enabled in devtools. This implies the request is completed
+  // so fast there is not enough time to detect the inactive button.
+  // await expect(
+  //   saveButton,
+  //   "save button should be disabled during the api call"
+  // ).toBeDisabled();
+  // await expect(
+  //   saveButton,
+  //   "save button should be enabled after the api call"
+  // ).toBeEnabled();
 
   // after saving is completed screen should have those new changed text before/after the page reload
   await expect(

--- a/e2e/explorer/workflow/active.spec.ts
+++ b/e2e/explorer/workflow/active.spec.ts
@@ -15,7 +15,10 @@ const defaultDescription = "A simple 'no-op' state that returns 'Hello world!'";
 
 test.beforeEach(async () => {
   namespace = await createNamespace();
-  workflow = await createWorkflow(namespace, faker.git.shortSha() + ".yaml");
+  workflow = await createWorkflow(
+    namespace,
+    faker.internet.domainName() + ".yaml"
+  );
 });
 
 test.afterEach(async () => {

--- a/e2e/explorer/workflow/diagramEditor.spec.ts
+++ b/e2e/explorer/workflow/diagramEditor.spec.ts
@@ -5,6 +5,7 @@ import { consumeEvent as consumeEventWorkflow } from "~/pages/namespace/Explorer
 import { createRevision } from "~/api/tree/mutate/createRevision";
 import { createWorkflow } from "~/api/tree/mutate/createWorkflow";
 import { faker } from "@faker-js/faker";
+import { headers } from "e2e/utils/testutils";
 
 let namespace = "";
 let workflow = "";
@@ -40,6 +41,7 @@ test.beforeEach(async () => {
       namespace,
       name: workflow,
     },
+    headers,
   });
 });
 
@@ -263,6 +265,7 @@ test("it is possible to use the diagram view on the revisions detail page as wel
       namespace,
       path: workflow,
     },
+    headers,
   });
 
   await page.goto(

--- a/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
+++ b/e2e/explorer/workflow/revisions/revisionsDetail.spec.ts
@@ -1,11 +1,11 @@
 import { createNamespace, deleteNamespace } from "../../../utils/namespace";
 import { expect, test } from "@playwright/test";
+import { headers, radixClick } from "../../../utils/testutils";
 
 import { noop as basicWorkflow } from "~/pages/namespace/Explorer/Tree/NewWorkflow/templates";
 import { createWorkflow } from "~/api/tree/mutate/createWorkflow";
 import { createWorkflowWithThreeRevisions } from "../../../utils/revisions";
 import { faker } from "@faker-js/faker";
-import { radixClick } from "../../../utils/testutils";
 
 let namespace = "";
 
@@ -30,6 +30,7 @@ test('it is possible to open the revision details of the "latest" revision', asy
       namespace,
       name: workflow,
     },
+    headers,
   });
 
   await page.goto(

--- a/e2e/explorer/workflow/revisions/revisionsList.spec.ts
+++ b/e2e/explorer/workflow/revisions/revisionsList.spec.ts
@@ -46,7 +46,7 @@ const actionCreateRevisionAndTag = async (page: Page) => {
 test("it is possible to navigate to the revisions tab", async ({ page }) => {
   const workflow = await createWorkflow(
     namespace,
-    faker.git.shortSha() + ".yaml"
+    faker.internet.domainName() + ".yaml"
   );
   await page.goto("/");
   await expect(
@@ -84,7 +84,7 @@ test("it is possible to navigate to the revisions tab", async ({ page }) => {
 test("latest is the only revision by default", async ({ page }) => {
   const workflow = await createWorkflow(
     namespace,
-    faker.git.shortSha() + ".yaml"
+    faker.internet.domainName() + ".yaml"
   );
   await page.goto(`${namespace}/explorer/workflow/revisions/${workflow}`);
 

--- a/e2e/explorer/workflow/revisions/revisionsList.spec.ts
+++ b/e2e/explorer/workflow/revisions/revisionsList.spec.ts
@@ -18,7 +18,7 @@ test.afterEach(async () => {
 });
 
 const actionCreateRevisionAndTag = async (page: Page) => {
-  const name = faker.system.commonFileName("yaml");
+  const name = `${faker.internet.domainWord()}.yaml`;
   const {
     revisionsReponse: [firstRev],
   } = await createWorkflowWithThreeRevisions(namespace, name);
@@ -46,7 +46,7 @@ const actionCreateRevisionAndTag = async (page: Page) => {
 test("it is possible to navigate to the revisions tab", async ({ page }) => {
   const workflow = await createWorkflow(
     namespace,
-    faker.internet.domainName() + ".yaml"
+    faker.internet.domainWord() + ".yaml"
   );
   await page.goto("/");
   await expect(
@@ -84,7 +84,7 @@ test("it is possible to navigate to the revisions tab", async ({ page }) => {
 test("latest is the only revision by default", async ({ page }) => {
   const workflow = await createWorkflow(
     namespace,
-    faker.internet.domainName() + ".yaml"
+    faker.internet.domainWord() + ".yaml"
   );
   await page.goto(`${namespace}/explorer/workflow/revisions/${workflow}`);
 

--- a/e2e/explorer/workflow/revisions/trafficShaping.spec.ts
+++ b/e2e/explorer/workflow/revisions/trafficShaping.spec.ts
@@ -5,6 +5,7 @@ import { noop as basicWorkflow } from "~/pages/namespace/Explorer/Tree/NewWorkfl
 import { createWorkflow } from "~/api/tree/mutate/createWorkflow";
 import { createWorkflowWithThreeRevisions } from "../../../utils/revisions";
 import { faker } from "@faker-js/faker";
+import { headers } from "e2e/utils/testutils";
 
 let namespace = "";
 
@@ -27,6 +28,7 @@ test("by default, traffic shaping is not configured", async ({ page }) => {
       namespace,
       name,
     },
+    headers,
   });
 
   await page.goto(`/${namespace}/explorer/workflow/revisions/${name}`);
@@ -70,6 +72,7 @@ test("it is not possible to save traffic shaping when the same revision is selec
       namespace,
       name,
     },
+    headers,
   });
 
   await page.goto(`/${namespace}/explorer/workflow/revisions/${name}`);

--- a/e2e/explorer/workflow/run.spec.ts
+++ b/e2e/explorer/workflow/run.spec.ts
@@ -6,6 +6,7 @@ import { noop as basicWorkflow } from "~/pages/namespace/Explorer/Tree/NewWorkfl
 import { createWorkflow } from "~/api/tree/mutate/createWorkflow";
 import { faker } from "@faker-js/faker";
 import { getInput } from "~/api/instances/query/input";
+import { headers } from "e2e/utils/testutils";
 
 let namespace = "";
 
@@ -29,6 +30,7 @@ test("it is possible to open and use the run workflow modal from the editor and 
       namespace,
       name: workflowName,
     },
+    headers,
   });
 
   await page.goto(`${namespace}/explorer/workflow/active/${workflowName}`);
@@ -99,6 +101,7 @@ test("it is possible to run the workflow by setting an input JSON via the editor
       namespace,
       name: workflowName,
     },
+    headers,
   });
 
   await page.goto(`${namespace}/explorer/workflow/active/${workflowName}`);
@@ -153,6 +156,7 @@ test("it is possible to run the workflow by setting an input JSON via the editor
       instanceId,
       namespace,
     },
+    headers,
   });
 
   const inputResponseString = atob(res.data);
@@ -180,6 +184,7 @@ test("it is possible to provide the input via generated form", async ({
       namespace,
       name: workflowName,
     },
+    headers,
   });
 
   await page.goto(`${namespace}/explorer/workflow/active/${workflowName}`);
@@ -266,6 +271,7 @@ test("it is possible to provide the input via generated form", async ({
       instanceId,
       namespace,
     },
+    headers,
   });
 
   const expectedJson = {
@@ -291,6 +297,7 @@ test("it is possible to provide the input via generated form and resolve form er
       namespace,
       name: workflowName,
     },
+    headers,
   });
 
   await page.goto(`${namespace}/explorer/workflow/active/${workflowName}`);
@@ -361,6 +368,7 @@ test("it is possible to provide the input via generated form and resolve form er
       instanceId,
       namespace,
     },
+    headers,
   });
 
   const expectedJson = {

--- a/e2e/instances/list/index.spec.ts
+++ b/e2e/instances/list/index.spec.ts
@@ -357,12 +357,6 @@ test("It will display child instances as well", async ({ page }) => {
   if (!childInstanceDetail)
     throw new Error("there should be at least one child instance");
 
-  const revisionId = page.getByTestId(
-    `instance-row-revision-id-${childInstanceDetail.id}`
-  );
-
-  await expect(revisionId, `revision id is "none"`).toContainText("none");
-
   const invoker = page.getByTestId(
     `instance-row-invoker-${childInstanceDetail.id}`
   );

--- a/e2e/instances/list/index.spec.ts
+++ b/e2e/instances/list/index.spec.ts
@@ -9,6 +9,7 @@ import {
 import { createWorkflow } from "~/api/tree/mutate/createWorkflow";
 import { faker } from "@faker-js/faker";
 import { getInstances } from "~/api/instances/query/get";
+import { headers } from "e2e/utils/testutils";
 import moment from "moment";
 import { runWorkflow } from "~/api/tree/mutate/runWorkflow";
 
@@ -28,6 +29,7 @@ test.beforeEach(async () => {
       namespace,
       name: simpleWorkflow,
     },
+    headers,
   });
 
   await createWorkflow({
@@ -37,6 +39,7 @@ test.beforeEach(async () => {
       namespace,
       name: workflowThatFails,
     },
+    headers,
   });
 });
 
@@ -52,6 +55,7 @@ const createBasicInstance = async () =>
       namespace,
       path: simpleWorkflow,
     },
+    headers,
   });
 
 const createFailedInstance = async () =>
@@ -61,6 +65,7 @@ const createFailedInstance = async () =>
       namespace,
       path: workflowThatFails,
     },
+    headers,
   });
 
 test("it displays a note, when there are no instances yet.", async ({
@@ -90,6 +95,7 @@ test("it renders the instance item correctly for failed and success status", asy
         limit: 10,
         offset: 0,
       },
+      headers,
     });
 
     const instanceDetail = instancesList.instances.results.find(
@@ -243,6 +249,7 @@ test("it provides a proper pagination", async ({ page }) => {
       namespace,
       name: parentWorkflow,
     },
+    headers,
   });
 
   await runWorkflow({
@@ -251,6 +258,7 @@ test("it provides a proper pagination", async ({ page }) => {
       namespace,
       path: parentWorkflow,
     },
+    headers,
   });
 
   await page.goto(`${namespace}/instances/`, { waitUntil: "networkidle" });
@@ -303,6 +311,7 @@ test("it provides a proper pagination", async ({ page }) => {
       limit: pageSize,
       offset: 2 * pageSize,
     },
+    headers,
   });
 
   const firstInstance = instancesListPage3.instances.results[0];
@@ -329,6 +338,7 @@ test("It will display child instances as well", async ({ page }) => {
       namespace,
       name: parentWorkflow,
     },
+    headers,
   });
 
   const parentInstance = await runWorkflow({
@@ -337,6 +347,7 @@ test("It will display child instances as well", async ({ page }) => {
       namespace,
       path: parentWorkflow,
     },
+    headers,
   });
 
   await page.goto(`${namespace}/instances/`, { waitUntil: "networkidle" });
@@ -348,6 +359,7 @@ test("It will display child instances as well", async ({ page }) => {
       limit: 15,
       offset: 0,
     },
+    headers,
   });
 
   const childInstanceDetail = instancesList.instances.results.find(

--- a/e2e/instances/list/index.spec.ts
+++ b/e2e/instances/list/index.spec.ts
@@ -124,13 +124,6 @@ test("it renders the instance item correctly for failed and success status", asy
       "on hover, a tooltip reveals full id"
     ).toContainText(instance.instance);
 
-    const revisionId = page.getByTestId(
-      `instance-row-revision-id-${instance.instance}`
-    );
-    await expect(revisionId, `the revision id is "latest"`).toContainText(
-      "latest"
-    );
-
     const invoker = page.getByTestId(
       `instance-row-invoker-${instance.instance}`
     );

--- a/e2e/instances/list/index.spec.ts
+++ b/e2e/instances/list/index.spec.ts
@@ -202,7 +202,7 @@ test("it renders the instance item correctly for failed and success status", asy
     await expect(
       page,
       "when the workflow name is clicked, page should navigate to the workflow page"
-    ).toHaveURL(`/${namespace}/explorer/workflow/active/${workflowName}`);
+    ).toHaveURL(`/${namespace}/explorer/workflow/active${workflowName}`);
 
     await page.goBack();
     await instanceItemRow.click();

--- a/e2e/setup/auth.ts
+++ b/e2e/setup/auth.ts
@@ -1,0 +1,74 @@
+/**
+ * Playwright suggests using "codegen" to generate a browser state that
+ * is then saved as a .json file and referenced in playwright.config.ts.
+ *
+ * See here: https://playwright.dev/docs/auth
+ *
+ * Since the .json would contain sensitive information, it should not be
+ * committed to the repo. Accordingly, we would have to repeat the steps
+ * to generate it before running any tests.
+ *
+ * Since there are only two variables and it is more convenient to set
+ * them via the environment, the code below is based on such a .json file,
+ * but just fills these values programatically.
+ *
+ * If breaking changes are made to our local storage, see the following
+ * docs on how to generate a new .json:
+ * https://playwright.dev/docs/codegen#preserve-authenticated-state
+ *
+ * (It is not necessary to write a test to generate the data, but it
+ * is possible to perform the required steps manually in the test browser
+ * and then save the generated json.)
+ *
+ * Irrelevant parts contained in the generated json have been removed
+ * (e.g., theme and initial workflow). See below for original json.
+ */
+
+const port = process.env.VITE_E2E_UI_PORT;
+const token = process.env.VITE_E2E_API_TOKEN || "";
+
+// if token is "", no token is added to the request.
+export const storageState = {
+  cookies: [],
+  origins: [
+    {
+      origin: `http://localhost:${port}`,
+      localStorage: [
+        {
+          name: "direktiv-store-api-key",
+          value: `{"state":{"apiKey":"${token}"},"version":0}`,
+        },
+      ],
+    },
+  ],
+};
+
+/*
+ * original JSON as generated with codegen:
+{
+  "cookies": [],
+  "origins": [
+    {
+      "origin": "http://localhost:3333",
+      "localStorage": [
+        {
+          "name": "direktiv-store-api-key",
+          "value": "{\"state\":{\"apiKey\":\"SECRET-KEY"},\"version\":0}"
+        },
+        {
+          "name": "direktiv-store-theme",
+          "value": "{\"state\":{\"storedTheme\":null},\"version\":0}"
+        },
+        {
+          "name": "direktiv-store-editor",
+          "value": "{\"state\":{\"layout\":\"code\"},\"version\":0}"
+        },
+        {
+          "name": "direktiv-store-namespace",
+          "value": "{\"state\":{\"namespace\":\"foobar\"},\"version\":0}"
+        }
+      ]
+    }
+  ]
+}
+ */

--- a/e2e/utils/broadcasts.ts
+++ b/e2e/utils/broadcasts.ts
@@ -3,6 +3,7 @@ import {
   BroadcastsSchemaType,
 } from "~/api/broadcasts/schema";
 
+import { headers } from "./testutils";
 import { updateBroadcasts } from "~/api/broadcasts/mutate/updateBroadcasts";
 
 export const createBroadcasts = async (namespace: string) => {
@@ -17,6 +18,7 @@ export const createBroadcasts = async (namespace: string) => {
       namespace,
     },
     headers: {
+      ...headers,
       "content-type": "application/json",
     },
   });

--- a/e2e/utils/namespace.ts
+++ b/e2e/utils/namespace.ts
@@ -1,5 +1,6 @@
 import { NamespaceListSchemaType } from "~/api/namespaces/schema";
 import { faker } from "@faker-js/faker";
+import { headers } from "./testutils";
 
 const apiUrl = process.env.VITE_DEV_API_DOMAIN;
 
@@ -10,6 +11,7 @@ export const createNamespace = () =>
     const name = createNamespaceName();
     fetch(`${apiUrl}/api/namespaces/${name}`, {
       method: "PUT",
+      headers,
     }).then((response) => {
       response.ok
         ? resolve(name)
@@ -21,6 +23,7 @@ export const deleteNamespace = (namespace: string) =>
   new Promise<void>((resolve, reject) => {
     fetch(`${apiUrl}/api/namespaces/${namespace}?recursive=true`, {
       method: "DELETE",
+      headers,
     }).then((response) => {
       response.ok
         ? resolve()
@@ -29,7 +32,7 @@ export const deleteNamespace = (namespace: string) =>
   });
 
 export const checkIfNamespaceExists = async (namespace: string) => {
-  const response = await fetch(`${apiUrl}/api/namespaces`);
+  const response = await fetch(`${apiUrl}/api/namespaces`, { headers });
   if (!response.ok) {
     throw `fetching namespaces failed with code ${response.status}`;
   }
@@ -46,7 +49,7 @@ export const checkIfNamespaceExists = async (namespace: string) => {
 // If you have spammed namespaces while writing tests, call this temporarily:
 // await cleanupNamespace();
 export const cleanupNamespaces = async () => {
-  const response = await fetch(`${apiUrl}/api/namespaces`);
+  const response = await fetch(`${apiUrl}/api/namespaces`, { headers });
   const namespaces = await response
     .json()
     .then((json: NamespaceListSchemaType) =>

--- a/e2e/utils/node.ts
+++ b/e2e/utils/node.ts
@@ -1,4 +1,5 @@
 import { NodeListSchemaType } from "~/api/tree/schema";
+import { headers } from "./testutils";
 
 const apiUrl = process.env.VITE_DEV_API_DOMAIN;
 
@@ -19,6 +20,7 @@ export const createWorkflow = (namespace: string, name: string) =>
     {
       method: "PUT",
       body: workflowExamples.noop,
+      headers,
     }
   ).then((response) => {
     if (!response.ok) {
@@ -32,6 +34,7 @@ export const createDirectory = (namespace: string, name: string) =>
     `${apiUrl}/api/namespaces/${namespace}/tree/${name}?op=create-directory`,
     {
       method: "PUT",
+      headers,
     }
   ).then((response) => {
     if (!response.ok) {
@@ -43,6 +46,7 @@ export const createDirectory = (namespace: string, name: string) =>
 export const deleteNode = (namespace: string, name: string) =>
   fetch(`${apiUrl}/api/namespaces/${namespace}/tree/${name}?op=delete-node`, {
     method: "DELETE",
+    headers,
   }).then((response) => {
     if (!response.ok) {
       throw `deleting node failed with code ${response.status}`;
@@ -51,14 +55,16 @@ export const deleteNode = (namespace: string, name: string) =>
   });
 
 export const checkIfNodeExists = (namespace: string, nodeName: string) =>
-  fetch(`${apiUrl}/api/namespaces/${namespace}/tree`).then((response) => {
-    if (!response.ok) {
-      throw `fetching nodes failed with code ${response.status}`;
+  fetch(`${apiUrl}/api/namespaces/${namespace}/tree`, { headers }).then(
+    (response) => {
+      if (!response.ok) {
+        throw `fetching nodes failed with code ${response.status}`;
+      }
+      return response.json().then((json: NodeListSchemaType) => {
+        const nodeInResponse = json?.children?.results
+          .map((node) => node.name)
+          .find((name) => name === nodeName);
+        return !!nodeInResponse;
+      });
     }
-    return response.json().then((json: NodeListSchemaType) => {
-      const nodeInResponse = json?.children?.results
-        .map((node) => node.name)
-        .find((name) => name === nodeName);
-      return !!nodeInResponse;
-    });
-  });
+  );

--- a/e2e/utils/registries.ts
+++ b/e2e/utils/registries.ts
@@ -1,5 +1,6 @@
 import { createRegistry } from "~/api/registries/mutate/createRegistry";
 import { faker } from "@faker-js/faker";
+import { headers } from "./testutils";
 
 export const createRegistries = async (namespace: string, amount = 5) => {
   const registries = Array.from({ length: amount }, () => ({
@@ -19,7 +20,7 @@ export const createRegistries = async (namespace: string, amount = 5) => {
           baseUrl: process.env.VITE_DEV_API_DOMAIN,
           namespace,
         },
-        headers: undefined,
+        headers,
       }).then(() => registry)
     )
   );

--- a/e2e/utils/revisions.ts
+++ b/e2e/utils/revisions.ts
@@ -1,5 +1,6 @@
 import { createRevision } from "~/api/tree/mutate/createRevision";
 import { createWorkflow } from "~/api/tree/mutate/createWorkflow";
+import { headers } from "./testutils";
 import { updateWorkflow } from "~/api/tree/mutate/updateWorkflow";
 
 const getRevisionContentVariation = (revision: number) => `\
@@ -22,6 +23,7 @@ export const createWorkflowWithThreeRevisions = async (
     baseUrl: process.env.VITE_DEV_API_DOMAIN,
     namespace,
     path: `${path ?? ""}${workflowName}`,
+    headers,
   };
 
   // revision 1
@@ -33,28 +35,35 @@ export const createWorkflowWithThreeRevisions = async (
       path,
       name: workflowName,
     },
+    headers,
   });
 
   const firstRevision = await createRevision({
     urlParams: commonUrlParams,
+    headers,
   });
 
   // revision 2
   await updateWorkflow({
     payload: contentRevision2,
     urlParams: commonUrlParams,
+    headers,
   });
   const secondRevision = await createRevision({
     urlParams: commonUrlParams,
+    headers,
   });
 
   // revision 3
   await updateWorkflow({
     payload: contentRevision3,
     urlParams: commonUrlParams,
+    headers,
   });
+
   const thirdRevision = await createRevision({
     urlParams: commonUrlParams,
+    headers,
   });
 
   return {

--- a/e2e/utils/secrets.ts
+++ b/e2e/utils/secrets.ts
@@ -1,5 +1,6 @@
 import { createSecret } from "~/api/secrets/mutate/createSecret";
 import { faker } from "@faker-js/faker";
+import { headers } from "./testutils";
 
 export const createSecrets = async (namespace: string, amount = 5) => {
   const secrets = Array.from({ length: amount }, () => ({
@@ -16,7 +17,7 @@ export const createSecrets = async (namespace: string, amount = 5) => {
           namespace,
           name: secret.name,
         },
-        headers: undefined,
+        headers,
       })
     )
   );

--- a/e2e/utils/testutils.ts
+++ b/e2e/utils/testutils.ts
@@ -1,5 +1,12 @@
 import { Locator } from "@playwright/test";
 
+const token = process.env.VITE_E2E_API_TOKEN;
+export const headers: { "Direktiv-Token"?: string } = token
+  ? {
+      "Direktiv-Token": token,
+    }
+  : {};
+
 export const getStyle = async (
   locator: Locator,
   property: string

--- a/e2e/utils/variables.ts
+++ b/e2e/utils/variables.ts
@@ -1,5 +1,6 @@
 import { MimeTypeSchema } from "~/pages/namespace/Settings/Variables/MimeTypeSelect";
 import { faker } from "@faker-js/faker";
+import { headers } from "./testutils";
 import { updateVar } from "~/api/variables/mutate/updateVariable";
 
 // Note: This makes sure only mimeTypes supported by the form are used,
@@ -23,6 +24,7 @@ export const createVariables = async (namespace: string, amount = 5) => {
           name: variable.name,
         },
         headers: {
+          ...headers,
           "content-type": variable.mimeType,
         },
       }).then((result) => ({

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^7.3.0",
-    "@playwright/test": "^1.33.0",
+    "@playwright/test": "^1.35.0",
     "@storybook/addon-actions": "^7.0.0-beta.53",
     "@storybook/addon-essentials": "^7.0.0-beta.53",
     "@storybook/addon-interactions": "^7.0.0-beta.53",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,7 @@ import * as dotenv from "dotenv";
 import { defineConfig, devices } from "@playwright/test";
 
 import { envVariablesSchema } from "./src/config/env/schema";
+import { storageState } from "./e2e/setup/auth";
 
 dotenv.config();
 const env = envVariablesSchema.parse(process.env);
@@ -27,7 +28,7 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL,
-
+    storageState,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     // trace: "on-first-retry",
     /* temporary override: this is expensive, but useful for debugging tests */

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -188,7 +188,6 @@
           "updatedAt": "last updated"
         },
         "tableRow": {
-          "noRevisionId": "none",
           "realtiveTime": "{{relativeTime}} ago",
           "openWorkflowTooltip": "click to open workflow"
         },

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -182,7 +182,6 @@
         "tableHeader": {
           "name": "name",
           "id": "id",
-          "revisionId": "revision id",
           "invoker": "trigger",
           "state": "state",
           "startedAt": "started at",

--- a/src/api/instances/schema.ts
+++ b/src/api/instances/schema.ts
@@ -5,7 +5,7 @@ const InstanceSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   id: z.string(),
-  as: z.string(), // f.e. "some.yaml:latest",
+  as: z.string(), // f.e. "some.yaml",
   status: z.enum(["pending", "failed", "crashed", "complete"]),
   errorCode: z.string(),
   errorMessage: z.string(),

--- a/src/pages/namespace/Instances/List/Row.tsx
+++ b/src/pages/namespace/Instances/List/Row.tsx
@@ -1,4 +1,3 @@
-import { ConditionalWrapper, twMergeClsx } from "~/util/helpers";
 import {
   HoverCard,
   HoverCardContent,
@@ -15,6 +14,7 @@ import {
 
 import Alert from "~/design/Alert";
 import Badge from "~/design/Badge";
+import { ConditionalWrapper } from "~/util/helpers";
 import CopyButton from "~/design/CopyButton";
 import { FC } from "react";
 import { InstanceSchemaType } from "~/api/instances/schema";
@@ -27,16 +27,12 @@ const InstanceTableRow: FC<{
   instance: InstanceSchemaType;
   namespace: string;
 }> = ({ instance, namespace }) => {
-  const [name, revision] = instance.as.split(":");
   const [invoker, childInstance] = instance.invoker.split(":");
   const updatedAt = useUpdatedAt(instance.updatedAt);
   const createdAt = useUpdatedAt(instance.createdAt);
   const navigate = useNavigate();
   const { t } = useTranslation();
-
   const isChild = invoker === "instance" && !!childInstance;
-
-  const isLatestRevision = revision === "latest" || isChild;
 
   return (
     <TooltipProvider>
@@ -64,13 +60,12 @@ const InstanceTableRow: FC<{
                 }}
                 to={pages.explorer.createHref({
                   namespace,
-                  path: name,
-                  subpage: isLatestRevision ? "workflow" : "workflow-revisions",
-                  revision: isLatestRevision ? undefined : revision,
+                  path: instance.as,
+                  subpage: "workflow",
                 })}
                 className="hover:underline"
               >
-                {name}
+                {instance.as}
               </Link>
             </TooltipTrigger>
             <TooltipContent>
@@ -99,15 +94,6 @@ const InstanceTableRow: FC<{
               />
             </TooltipContent>
           </Tooltip>
-        </TableCell>
-        <TableCell>
-          <Badge
-            data-testid={`instance-row-revision-id-${instance.id}`}
-            variant="outline"
-            className={twMergeClsx(!revision && "italic")}
-          >
-            {revision ?? t("pages.instances.list.tableRow.noRevisionId")}
-          </Badge>
         </TableCell>
         <TableCell>
           <ConditionalWrapper

--- a/src/pages/namespace/Instances/List/index.tsx
+++ b/src/pages/namespace/Instances/List/index.tsx
@@ -57,9 +57,6 @@ const InstancesListPage = () => {
                 {t("pages.instances.list.tableHeader.id")}
               </TableHeaderCell>
               <TableHeaderCell className="w-28">
-                {t("pages.instances.list.tableHeader.revisionId")}
-              </TableHeaderCell>
-              <TableHeaderCell className="w-28">
                 {t("pages.instances.list.tableHeader.invoker")}
               </TableHeaderCell>
               <TableHeaderCell className="w-28">
@@ -76,7 +73,7 @@ const InstancesListPage = () => {
           <TableBody>
             {noResults ? (
               <TableRow className="hover:bg-inherit dark:hover:bg-inherit">
-                <TableCell colSpan={7}>
+                <TableCell colSpan={6}>
                   <NoResult
                     message={
                       hasFilters

--- a/src/pages/namespace/Settings/index.tsx
+++ b/src/pages/namespace/Settings/index.tsx
@@ -1,7 +1,6 @@
 import ApiKey from "./ApiKey";
 import Broadcasts from "./Broadcasts";
 import { FC } from "react";
-import Input from "~/design/Input";
 import RegistriesList from "./Registries";
 import SecretsList from "./Secrets";
 import VariablesList from "./Variables";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2185,13 +2185,13 @@
     picocolors "^1.0.0"
     tslib "^2.5.0"
 
-"@playwright/test@^1.33.0":
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.33.0.tgz#669ef859efb81b143dfc624eef99d1dd92a81b67"
-  integrity sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==
+"@playwright/test@^1.35.0":
+  version "1.36.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.36.2.tgz#9edd68a02b0929c5d78d9479a654ceb981dfb592"
+  integrity sha512-2rVZeyPRjxfPH6J0oGJqE8YxiM1IBRyM8hyrXYK7eSiAqmbNhxwcLa7dZ7fy9Kj26V7FYia5fh9XJRq4Dqme+g==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.33.0"
+    playwright-core "1.36.2"
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -11051,10 +11051,10 @@ pkg-types@^1.0.1:
     mlly "^1.0.0"
     pathe "^1.0.0"
 
-playwright-core@1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.33.0.tgz#269efe29a927cd6d144d05f3c2d2f72bd72447a1"
-  integrity sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==
+playwright-core@1.36.2:
+  version "1.36.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.36.2.tgz#32382f2d96764c24c65a86ea336cf79721c2e50e"
+  integrity sha512-sQYZt31dwkqxOrP7xy2ggDfEzUxM1lodjhsQ3NMMv5uGTRDsLxU0e4xf4wwMkF2gplIxf17QMBCodSFgm6bFVQ==
 
 pluralize@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
As the api will no longer provide the revision at the instance endpoint (`as: "workflow:latest` changed to `as: "workflow`) we need to remove the column.

This also makes the code a lot cleaner since we now always link to the latest revision.

I have adjusted the e2e tests, but without running them. It would be great if @sebxian could run the tests locally against an api that doesn't require an api token.