### PR TITLE
Tooltip Copy Badge

### DIFF
--- a/e2e/instances/list/index.spec.ts
+++ b/e2e/instances/list/index.spec.ts
@@ -115,7 +115,7 @@ test("it renders the instance item correctly for failed and success status", asy
       `instance-row-wrap-${instance.instance}`
     );
     const instanceItemId = page.getByTestId(
-      `instance-row-id-${instance.instance}`
+      `tooltip-copy-badge-${instance.instance}`
     );
     await expect(
       instanceItemId,
@@ -123,7 +123,7 @@ test("it renders the instance item correctly for failed and success status", asy
     ).toContainText(instance.instance.slice(0, 8));
     await instanceItemId.hover();
     const idTooltip = page.getByTestId(
-      `instance-row-id-full-${instance.instance}`
+      `tooltip-copy-badge-content-${instance.instance}`
     );
     await expect(
       idTooltip,
@@ -317,7 +317,7 @@ test("it provides a proper pagination", async ({ page }) => {
   const firstInstance = instancesListPage3.instances.results[0];
   if (!firstInstance) throw new Error("there should be at least one instance");
   const instanceItemId = page.getByTestId(
-    `instance-row-id-${firstInstance.id}`
+    `tooltip-copy-badge-${firstInstance.id}`
   );
   await expect(
     instanceItemId,
@@ -375,7 +375,7 @@ test("It will display child instances as well", async ({ page }) => {
   await expect(invoker, `invoker is "instance"`).toContainText("instance");
 
   const instanceItemId = page.getByTestId(
-    `instance-row-id-${childInstanceDetail.id}`
+    `tooltip-copy-badge-${childInstanceDetail.id}`
   );
   await expect(
     instanceItemId,
@@ -383,7 +383,7 @@ test("It will display child instances as well", async ({ page }) => {
   ).toContainText(childInstanceDetail.id.slice(0, 8));
   await instanceItemId.hover();
   const idTooltip = page.getByTestId(
-    `instance-row-id-full-${childInstanceDetail.id}`
+    `tooltip-copy-badge-content-${childInstanceDetail.id}`
   );
   await expect(idTooltip, "on hover, a tooltip reveals full id").toContainText(
     childInstanceDetail.id

--- a/src/design/TooltipCopyBadge/index.stories.tsx
+++ b/src/design/TooltipCopyBadge/index.stories.tsx
@@ -1,0 +1,17 @@
+import TooltipCopyBadge from ".";
+import { TooltipProvider } from "../Tooltip";
+
+export default {
+  title: "Components/TooltipCopyBadge",
+};
+
+export const Default = () => (
+  <div>
+    <TooltipProvider>
+      <TooltipCopyBadge
+        value="some-rather-a-bit-too-long-text"
+        displayValue="short-text"
+      />
+    </TooltipProvider>
+  </div>
+);

--- a/src/design/TooltipCopyBadge/index.stories.tsx
+++ b/src/design/TooltipCopyBadge/index.stories.tsx
@@ -6,12 +6,38 @@ export default {
 };
 
 export const Default = () => (
-  <div>
+  <div className="flex gap-2">
     <TooltipProvider>
+      <TooltipCopyBadge value="some-rather-a-bit-too-long-text" icon="complete">
+        short-text
+      </TooltipCopyBadge>
+      <TooltipCopyBadge
+        variant="secondary"
+        value="some-rather-a-bit-too-long-text"
+        icon="pending"
+      >
+        short-text
+      </TooltipCopyBadge>
+      <TooltipCopyBadge
+        variant="outline"
+        value="some-rather-a-bit-too-long-text"
+      >
+        short-text
+      </TooltipCopyBadge>
       <TooltipCopyBadge
         value="some-rather-a-bit-too-long-text"
-        displayValue="short-text"
-      />
+        variant="destructive"
+        icon="failed"
+      >
+        short-text
+      </TooltipCopyBadge>
+      <TooltipCopyBadge
+        value="some-rather-a-bit-too-long-text"
+        variant="success"
+        icon="complete"
+      >
+        short-text
+      </TooltipCopyBadge>
     </TooltipProvider>
   </div>
 );

--- a/src/design/TooltipCopyBadge/index.tsx
+++ b/src/design/TooltipCopyBadge/index.tsx
@@ -11,11 +11,11 @@ const TooltipCopyBadge = ({
   displayValue: string;
 }) => (
   <Tooltip>
-    <TooltipTrigger data-testid={`instance-row-id-${value}`}>
+    <TooltipTrigger data-testid={`tooltip-copy-badge-${value}`}>
       <Badge variant="outline">{displayValue}</Badge>
     </TooltipTrigger>
     <TooltipContent
-      data-testid={`instance-row-id-full-${value}`}
+      data-testid={`tooltip-copy-badge-content-${value}`}
       className="flex gap-2 align-middle"
     >
       {value}

--- a/src/design/TooltipCopyBadge/index.tsx
+++ b/src/design/TooltipCopyBadge/index.tsx
@@ -1,0 +1,35 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "~/design/Tooltip";
+
+import Badge from "~/design/Badge";
+import CopyButton from "~/design/CopyButton";
+
+const TooltipCopyBadge = ({
+  value,
+  displayValue,
+}: {
+  value: string;
+  displayValue: string;
+}) => (
+  <Tooltip>
+    <TooltipTrigger data-testid={`instance-row-id-${value}`}>
+      <Badge variant="outline">{displayValue}</Badge>
+    </TooltipTrigger>
+    <TooltipContent
+      data-testid={`instance-row-id-full-${value}`}
+      className="flex gap-2 align-middle"
+    >
+      {value}
+      <CopyButton
+        value={value}
+        buttonProps={{
+          size: "sm",
+          onClick: (e) => {
+            e.stopPropagation();
+          },
+        }}
+      />
+    </TooltipContent>
+  </Tooltip>
+);
+
+export default TooltipCopyBadge;

--- a/src/design/TooltipCopyBadge/index.tsx
+++ b/src/design/TooltipCopyBadge/index.tsx
@@ -1,18 +1,17 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/design/Tooltip";
 
 import Badge from "~/design/Badge";
+import { ComponentProps } from "react";
 import CopyButton from "~/design/CopyButton";
 
-const TooltipCopyBadge = ({
-  value,
-  displayValue,
-}: {
+type TooltipCopyBadge = ComponentProps<typeof Badge> & {
   value: string;
-  displayValue: string;
-}) => (
+};
+
+const TooltipCopyBadge = ({ value, ...props }: TooltipCopyBadge) => (
   <Tooltip>
     <TooltipTrigger data-testid={`tooltip-copy-badge-${value}`}>
-      <Badge variant="outline">{displayValue}</Badge>
+      <Badge {...props} />
     </TooltipTrigger>
     <TooltipContent
       data-testid={`tooltip-copy-badge-content-${value}`}

--- a/src/pages/namespace/Instances/List/Row.tsx
+++ b/src/pages/namespace/Instances/List/Row.tsx
@@ -75,10 +75,9 @@ const InstanceTableRow: FC<{
           </Tooltip>
         </TableCell>
         <TableCell>
-          <TooltipCopyBadge
-            value={instance.id}
-            displayValue={instance.id.slice(0, 8)}
-          />
+          <TooltipCopyBadge value={instance.id} variant="outline">
+            {instance.id.slice(0, 8)}
+          </TooltipCopyBadge>
         </TableCell>
         <TableCell>
           <ConditionalWrapper

--- a/src/pages/namespace/Instances/List/Row.tsx
+++ b/src/pages/namespace/Instances/List/Row.tsx
@@ -18,6 +18,7 @@ import { ConditionalWrapper } from "~/util/helpers";
 import CopyButton from "~/design/CopyButton";
 import { FC } from "react";
 import { InstanceSchemaType } from "~/api/instances/schema";
+import TooltipCopyBadge from "~/design/TooltipCopyBadge";
 import { pages } from "~/util/router/pages";
 import { statusToBadgeVariant } from "../utils";
 import { useTranslation } from "react-i18next";
@@ -74,26 +75,10 @@ const InstanceTableRow: FC<{
           </Tooltip>
         </TableCell>
         <TableCell>
-          <Tooltip>
-            <TooltipTrigger data-testid={`instance-row-id-${instance.id}`}>
-              <Badge variant="outline">{instance.id.slice(0, 8)}</Badge>
-            </TooltipTrigger>
-            <TooltipContent
-              data-testid={`instance-row-id-full-${instance.id}`}
-              className="flex gap-2 align-middle"
-            >
-              {instance.id}
-              <CopyButton
-                value={instance.id}
-                buttonProps={{
-                  size: "sm",
-                  onClick: (e) => {
-                    e.stopPropagation();
-                  },
-                }}
-              />
-            </TooltipContent>
-          </Tooltip>
+          <TooltipCopyBadge
+            value={instance.id}
+            displayValue={instance.id.slice(0, 8)}
+          />
         </TableCell>
         <TableCell>
           <ConditionalWrapper


### PR DESCRIPTION
This adds a design component and corresponding storybook story, as discussed in person with @stefan-kracht .

I decided the name should start with "Tooltip" after all, because it requires to be wrapped in a TooltipProvider.

We discussed making the tooltip optional in the future, but my current thoughts on this are: It might make things complicated (regarding the requirement of having a parent TooltipProvider), and my main reason to componentize this was the boilerplate code required for the tooltip. For use cases where we just need a badge without tooltip, I am not sure using a component (other than `design/Badge` is justified.

I have added the component to the instances list and updated the e2e tests accordingly (because test-ids have changed).
