### PR TITLE
[DIR-626] add pagination and search to settings page

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -327,7 +327,10 @@
       "variables": {
         "list": {
           "title": "Variables",
-          "empty": "No variables exist yet"
+          "empty": "No variables exist yet",
+          "createBtn": "Create Variable",
+          "searchPlaceholder": "Filter variables...",
+          "emptySearch": "No variables match your search"
         },
         "delete": {
           "description": "Are you sure you want to delete <b>{{name}}</b>?<br/> This cannot be undone."

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -299,7 +299,10 @@
       "secrets": {
         "list": {
           "title": "Secrets",
-          "empty": "No secrets exist yet"
+          "empty": "No secrets exist yet",
+          "createBtn": "Create Secret",
+          "searchPlaceholder": "Filter Secrets...",
+          "emptySearch": "No secret matches your search"
         },
         "delete": {
           "description": "Are you sure you want to delete <b>{{name}}</b>?<br/> This cannot be undone."
@@ -312,7 +315,10 @@
       "registries": {
         "list": {
           "title": "Container Registries",
-          "empty": "No registries exist yet"
+          "empty": "No registries exist yet",
+          "createBtn": "Create Registry",
+          "searchPlaceholder": "Filter Registries...",
+          "emptySearch": "No registry matches your search"
         },
         "delete": {
           "description": "Are you sure you want to delete <b>{{name}}</b>?<br/> This cannot be undone."

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -327,7 +327,12 @@
           "description": "Add a container registry",
           "url": "URL",
           "user": "User",
-          "password": "Password"
+          "password": "Password",
+          "testConnectionBtn": {
+            "label": "Test connection",
+            "success": "Connection successful",
+            "error": "Connection failed"
+          }
         }
       },
       "variables": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -300,8 +300,8 @@
         "list": {
           "title": "Secrets",
           "empty": "No secrets exist yet",
-          "createBtn": "Create Secret",
-          "searchPlaceholder": "Filter Secrets...",
+          "createBtn": "Create secret",
+          "searchPlaceholder": "Filter secrets...",
           "emptySearch": "No secret matches your search"
         },
         "delete": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -330,7 +330,7 @@
           "empty": "No variables exist yet",
           "createBtn": "Create Variable",
           "searchPlaceholder": "Filter variables...",
-          "emptySearch": "No variables match your search"
+          "emptySearch": "No variable matches your search"
         },
         "delete": {
           "description": "Are you sure you want to delete <b>{{name}}</b>?<br/> This cannot be undone."

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -316,8 +316,8 @@
         "list": {
           "title": "Container Registries",
           "empty": "No registries exist yet",
-          "createBtn": "Create Registry",
-          "searchPlaceholder": "Filter Registries...",
+          "createBtn": "Create registry",
+          "searchPlaceholder": "Filter registries...",
           "emptySearch": "No registry matches your search"
         },
         "delete": {
@@ -339,7 +339,7 @@
         "list": {
           "title": "Variables",
           "empty": "No variables exist yet",
-          "createBtn": "Create Variable",
+          "createBtn": "Create variable",
           "searchPlaceholder": "Filter variables...",
           "emptySearch": "No variable matches your search"
         },

--- a/src/api/registries/mutate/testConnection.ts
+++ b/src/api/registries/mutate/testConnection.ts
@@ -1,0 +1,50 @@
+import { RegistryTestConnectionSchema } from "../schema";
+import { apiFactory } from "~/api/apiFactory";
+import { useApiKey } from "~/util/store/apiKey";
+import { useMutation } from "@tanstack/react-query";
+import { useNamespace } from "~/util/store/namespace";
+
+export const testConnection = apiFactory({
+  url: ({ baseUrl }: { baseUrl?: string }) =>
+    `${baseUrl ?? ""}/api/functions/registries/test`,
+  method: "POST",
+  schema: RegistryTestConnectionSchema,
+});
+
+export const useTestConnection = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: () => void;
+  onError?: () => void;
+} = {}) => {
+  const apiKey = useApiKey();
+  const namespace = useNamespace();
+
+  if (!namespace) {
+    throw new Error("namespace is undefined");
+  }
+
+  return useMutation({
+    mutationFn: ({
+      url,
+      username,
+      password,
+    }: {
+      url: string;
+      username: string;
+      password: string;
+    }) =>
+      testConnection({
+        apiKey: apiKey ?? undefined,
+        urlParams: {},
+        payload: { url, username, password },
+      }),
+    onSuccess: () => {
+      onSuccess?.();
+    },
+    onError: () => {
+      onError?.();
+    },
+  });
+};

--- a/src/api/registries/schema.ts
+++ b/src/api/registries/schema.ts
@@ -22,6 +22,8 @@ export const RegistryListSchema = z.object({
   registries: z.array(RegistrySchema),
 });
 
+export const RegistryTestConnectionSchema = z.object({});
+
 export const RegistryCreatedSchema = z.null();
 
 export const RegistryDeletedSchema = z.null();

--- a/src/pages/namespace/Settings/Registries/Create.tsx
+++ b/src/pages/namespace/Settings/Registries/Create.tsx
@@ -99,11 +99,7 @@ const Create = ({ onSuccess }: CreateProps) => {
               {t("components.button.label.cancel")}
             </Button>
           </DialogClose>
-          <Button
-            data-testid="registry-create-submit"
-            type="submit"
-            variant="primary"
-          >
+          <Button data-testid="registry-create-submit" type="submit">
             {t("components.button.label.create")}
           </Button>
         </DialogFooter>

--- a/src/pages/namespace/Settings/Registries/Create/TestConnectionButton.tsx
+++ b/src/pages/namespace/Settings/Registries/Create/TestConnectionButton.tsx
@@ -1,0 +1,72 @@
+import { CheckCircle2, CircleDashed, XCircle } from "lucide-react";
+import { ComponentProps, FC, useEffect, useState } from "react";
+
+import Button from "~/design/Button";
+import { useTestConnection } from "~/api/registries/mutate/testConnection";
+import { useTranslation } from "react-i18next";
+
+export const TestConnectionButton = ({
+  isValid,
+  getValues,
+}: {
+  isValid: boolean;
+  getValues: (name: "url" | "user" | "password") => string;
+}) => {
+  const { t } = useTranslation();
+  const [testSuccessful, setTestSuccessful] = useState<boolean | null>(null); // null = not tested yet
+
+  useEffect(() => {
+    // reset test status after 3 seconds
+    if (testSuccessful !== null) {
+      const timeout = setTimeout(() => {
+        setTestSuccessful(null);
+      }, 3000);
+      return () => clearTimeout(timeout);
+    }
+  }, [testSuccessful]);
+
+  const { mutate: testConnection, isLoading } = useTestConnection({
+    onSuccess: () => {
+      setTestSuccessful(true);
+    },
+    onError: () => {
+      setTestSuccessful(false);
+    },
+  });
+
+  const onTestConnectionClick = () => {
+    testConnection({
+      url: getValues("url"),
+      username: getValues("user"),
+      password: getValues("password"),
+    });
+  };
+
+  let variant: ComponentProps<typeof Button>["variant"] = "outline";
+  let Icon: FC<React.SVGProps<SVGSVGElement>> = CircleDashed;
+  let label = t("pages.settings.registries.create.testConnectionBtn.label");
+
+  if (testSuccessful === true) {
+    variant = "primary";
+    Icon = CheckCircle2;
+    label = t("pages.settings.registries.create.testConnectionBtn.success");
+  }
+  if (testSuccessful === false) {
+    variant = "destructive";
+    Icon = XCircle;
+    label = t("pages.settings.registries.create.testConnectionBtn.error");
+  }
+
+  return (
+    <Button
+      onClick={onTestConnectionClick}
+      loading={isLoading}
+      disabled={!isValid || isLoading}
+      type="button"
+      variant={variant}
+    >
+      {!isLoading && <Icon />}
+      {label}
+    </Button>
+  );
+};

--- a/src/pages/namespace/Settings/Registries/Create/index.tsx
+++ b/src/pages/namespace/Settings/Registries/Create/index.tsx
@@ -15,6 +15,7 @@ import Button from "~/design/Button";
 import FormErrors from "~/componentsNext/FormErrors";
 import Input from "~/design/Input";
 import { PlusCircle } from "lucide-react";
+import { TestConnectionButton } from "./TestConnectionButton";
 import { useCreateRegistry } from "~/api/registries/mutate/createRegistry";
 import { useTranslation } from "react-i18next";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -23,10 +24,7 @@ type CreateProps = { onSuccess: () => void };
 
 const Create = ({ onSuccess }: CreateProps) => {
   const { t } = useTranslation();
-
-  const { mutate: createRegistryMutation } = useCreateRegistry({
-    onSuccess,
-  });
+  const { mutate: createRegistryMutation } = useCreateRegistry({ onSuccess });
 
   const onSubmit: SubmitHandler<RegistryFormSchemaType> = (data) => {
     createRegistryMutation(data);
@@ -35,7 +33,8 @@ const Create = ({ onSuccess }: CreateProps) => {
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    getValues,
+    formState: { errors, isValid },
   } = useForm<RegistryFormSchemaType>({
     resolver: zodResolver(RegistryFormSchema),
   });
@@ -53,9 +52,7 @@ const Create = ({ onSuccess }: CreateProps) => {
             {t("pages.settings.registries.create.description")}
           </DialogTitle>
         </DialogHeader>
-
         <FormErrors errors={errors} className="mb-5" />
-
         <fieldset className="flex items-center gap-5">
           <label className="w-[150px] text-right" htmlFor="url">
             {t("pages.settings.registries.create.url")}
@@ -67,7 +64,6 @@ const Create = ({ onSuccess }: CreateProps) => {
             {...register("url")}
           />
         </fieldset>
-
         <fieldset className="flex items-center gap-5">
           <label className="w-[150px] text-right" htmlFor="user">
             {t("pages.settings.registries.create.user")}
@@ -79,7 +75,6 @@ const Create = ({ onSuccess }: CreateProps) => {
             {...register("user")}
           />
         </fieldset>
-
         <fieldset className="flex items-center gap-5">
           <label className="w-[150px] text-right" htmlFor="password">
             {t("pages.settings.registries.create.password")}
@@ -99,6 +94,7 @@ const Create = ({ onSuccess }: CreateProps) => {
               {t("components.button.label.cancel")}
             </Button>
           </DialogClose>
+          <TestConnectionButton getValues={getValues} isValid={isValid} />
           <Button data-testid="registry-create-submit" type="submit">
             {t("components.button.label.create")}
           </Button>

--- a/src/pages/namespace/Settings/Registries/index.tsx
+++ b/src/pages/namespace/Settings/Registries/index.tsx
@@ -46,11 +46,12 @@ const RegistriesList: FC = () => {
           <Container className="h-5" />
           {t("pages.settings.registries.list.title")}
         </h3>
-
         <CreateItemButton
           onClick={() => setCreateRegistry(true)}
           data-testid="registry-create"
-        />
+        >
+          {t("pages.settings.registries.list.createBtn")}
+        </CreateItemButton>
       </div>
 
       <Card>

--- a/src/pages/namespace/Settings/Registries/index.tsx
+++ b/src/pages/namespace/Settings/Registries/index.tsx
@@ -1,4 +1,5 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect, useMemo, useState } from "react";
+import { Pagination, PaginationLink } from "~/design/Pagination";
 import { Table, TableBody } from "~/design/Table";
 
 import { Card } from "~/design/Card";
@@ -8,11 +9,15 @@ import CreateItemButton from "../components/CreateItemButton";
 import Delete from "./Delete";
 import { Dialog } from "~/design/Dialog";
 import EmptyList from "../components/EmptyList";
+import Input from "~/design/Input";
 import ItemRow from "../components/ItemRow";
+import PaginationProvider from "~/componentsNext/PaginationProvider";
 import { RegistrySchemaType } from "~/api/registries/schema";
 import { useDeleteRegistry } from "~/api/registries/mutate/deleteRegistry";
 import { useRegistries } from "~/api/registries/query/get";
 import { useTranslation } from "react-i18next";
+
+const pageSize = 10;
 
 const RegistriesList: FC = () => {
   const { t } = useTranslation();
@@ -20,8 +25,18 @@ const RegistriesList: FC = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [deleteRegistry, setDeleteRegistry] = useState<RegistrySchemaType>();
   const [createRegistry, setCreateRegistry] = useState(false);
+  const [search, setSearch] = useState("");
+  const isSearch = search.length > 0;
 
   const { data, isFetched } = useRegistries();
+
+  const filteredItems = useMemo(
+    () =>
+      (data?.registries ?? [])?.filter(
+        (item) => !isSearch || item.name.includes(search)
+      ),
+    [data?.registries, isSearch, search]
+  );
 
   const { mutate: deleteRegistryMutation } = useDeleteRegistry({
     onSuccess: () => {
@@ -41,41 +56,92 @@ const RegistriesList: FC = () => {
 
   return (
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-      <div className="mb-3 flex flex-row justify-between">
-        <h3 className="flex items-center gap-x-2 pb-2 pt-1 font-bold">
-          <Container className="h-5" />
-          {t("pages.settings.registries.list.title")}
-        </h3>
-        <CreateItemButton
-          onClick={() => setCreateRegistry(true)}
-          data-testid="registry-create"
-        >
-          {t("pages.settings.registries.list.createBtn")}
-        </CreateItemButton>
-      </div>
-
-      <Card>
-        {data?.registries.length ? (
-          <Table>
-            <TableBody>
-              {data?.registries.map((item, i) => (
-                <ItemRow key={i} item={item} onDelete={setDeleteRegistry} />
-              ))}
-            </TableBody>
-          </Table>
-        ) : (
-          <EmptyList>{t("pages.settings.registries.list.empty")}</EmptyList>
+      <PaginationProvider items={filteredItems} pageSize={pageSize}>
+        {({
+          currentItems,
+          goToFirstPage,
+          goToPage,
+          goToNextPage,
+          goToPreviousPage,
+          currentPage,
+          pagesList,
+          totalPages,
+        }) => (
+          <>
+            <div className="mb-4 flex flex-col gap-4 sm:flex-row">
+              <h3 className="flex grow items-center gap-x-2 pb-2 pt-1 font-bold">
+                <Container className="h-5" />
+                {t("pages.settings.registries.list.title")}
+              </h3>
+              <Input
+                className="sm:w-60"
+                value={search}
+                onChange={(e) => {
+                  setSearch(e.target.value);
+                  goToFirstPage();
+                }}
+                placeholder={t(
+                  "pages.settings.registries.list.searchPlaceholder"
+                )}
+              />
+              <CreateItemButton
+                onClick={() => setCreateRegistry(true)}
+                data-testid="registry-create"
+              >
+                {t("pages.settings.registries.list.createBtn")}
+              </CreateItemButton>
+            </div>
+            <Card className="mb-4">
+              {currentItems.length ? (
+                <Table>
+                  <TableBody>
+                    {currentItems.map((item, i) => (
+                      <ItemRow
+                        key={i}
+                        item={item}
+                        onDelete={setDeleteRegistry}
+                      />
+                    ))}
+                  </TableBody>
+                </Table>
+              ) : (
+                <EmptyList>
+                  {t(
+                    isSearch
+                      ? "pages.settings.registries.list.emptySearch"
+                      : "pages.settings.registries.list.empty"
+                  )}
+                </EmptyList>
+              )}
+            </Card>
+            {totalPages > 1 && (
+              <Pagination>
+                <PaginationLink
+                  icon="left"
+                  onClick={() => goToPreviousPage()}
+                />
+                {pagesList.map((p) => (
+                  <PaginationLink
+                    active={currentPage === p}
+                    key={`${p}`}
+                    onClick={() => goToPage(p)}
+                  >
+                    {p}
+                  </PaginationLink>
+                ))}
+                <PaginationLink icon="right" onClick={() => goToNextPage()} />
+              </Pagination>
+            )}
+          </>
         )}
-        {deleteRegistry && (
-          <Delete
-            name={deleteRegistry.name}
-            onConfirm={() =>
-              deleteRegistryMutation({ registry: deleteRegistry })
-            }
-          />
-        )}
-        {createRegistry && <Create onSuccess={() => setDialogOpen(false)} />}
-      </Card>
+      </PaginationProvider>
+      {deleteRegistry && (
+        <Delete
+          name={deleteRegistry.name}
+          onConfirm={() => deleteRegistryMutation({ registry: deleteRegistry })}
+        />
+      )}
+      {createRegistry && <Create onSuccess={() => setDialogOpen(false)} />}
     </Dialog>
   );
 };

--- a/src/pages/namespace/Settings/Registries/index.tsx
+++ b/src/pages/namespace/Settings/Registries/index.tsx
@@ -120,13 +120,13 @@ const RegistriesList: FC = () => {
                   icon="left"
                   onClick={() => goToPreviousPage()}
                 />
-                {pagesList.map((p) => (
+                {pagesList.map((page) => (
                   <PaginationLink
-                    active={currentPage === p}
-                    key={`${p}`}
-                    onClick={() => goToPage(p)}
+                    active={currentPage === page}
+                    key={`${page}`}
+                    onClick={() => goToPage(page)}
                   >
-                    {p}
+                    {page}
                   </PaginationLink>
                 ))}
                 <PaginationLink icon="right" onClick={() => goToNextPage()} />

--- a/src/pages/namespace/Settings/Secrets/Create.tsx
+++ b/src/pages/namespace/Settings/Secrets/Create.tsx
@@ -82,11 +82,7 @@ const Create = ({ onSuccess }: CreateProps) => {
               {t("components.button.label.cancel")}
             </Button>
           </DialogClose>
-          <Button
-            data-testid="secret-create-submit"
-            type="submit"
-            variant="primary"
-          >
+          <Button data-testid="secret-create-submit" type="submit">
             {t("components.button.label.create")}
           </Button>
         </DialogFooter>

--- a/src/pages/namespace/Settings/Secrets/index.tsx
+++ b/src/pages/namespace/Settings/Secrets/index.tsx
@@ -1,4 +1,5 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect, useMemo, useState } from "react";
+import { Pagination, PaginationLink } from "~/design/Pagination";
 import { Table, TableBody } from "~/design/Table";
 
 import { Card } from "~/design/Card";
@@ -7,12 +8,16 @@ import CreateItemButton from "../components/CreateItemButton";
 import Delete from "./Delete";
 import { Dialog } from "~/design/Dialog";
 import EmptyList from "../components/EmptyList";
+import Input from "~/design/Input";
 import ItemRow from "../components/ItemRow";
+import PaginationProvider from "~/componentsNext/PaginationProvider";
 import { SecretSchemaType } from "~/api/secrets/schema";
 import { SquareAsterisk } from "lucide-react";
 import { useDeleteSecret } from "~/api/secrets/mutate/deleteSecret";
 import { useSecrets } from "~/api/secrets/query/get";
 import { useTranslation } from "react-i18next";
+
+const pageSize = 10;
 
 const SecretsList: FC = () => {
   const { t } = useTranslation();
@@ -20,8 +25,18 @@ const SecretsList: FC = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [deleteSecret, setDeleteSecret] = useState<SecretSchemaType>();
   const [createSecret, setCreateSecret] = useState(false);
+  const [search, setSearch] = useState("");
+  const isSearch = search.length > 0;
 
   const { data, isFetched } = useSecrets();
+
+  const filteredItems = useMemo(
+    () =>
+      (data?.secrets.results ?? [])?.filter(
+        (item) => !isSearch || item.name.includes(search)
+      ),
+    [data?.secrets.results, isSearch, search]
+  );
 
   const { mutate: deleteSecretMutation } = useDeleteSecret({
     onSuccess: () => {
@@ -41,40 +56,86 @@ const SecretsList: FC = () => {
 
   return (
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-      <div className="mb-3 flex flex-row justify-between">
-        <h3 className="flex items-center gap-x-2 pb-2 pt-1 font-bold">
-          <SquareAsterisk className="h-5" />
-          {t("pages.settings.secrets.list.title")}
-        </h3>
-
-        <CreateItemButton
-          data-testid="secret-create"
-          onClick={() => setCreateSecret(true)}
-        >
-          {t("pages.settings.secrets.list.createBtn")}
-        </CreateItemButton>
-      </div>
-
-      <Card>
-        {data?.secrets.results.length ? (
-          <Table>
-            <TableBody>
-              {data?.secrets.results.map((item, i) => (
-                <ItemRow item={item} key={i} onDelete={setDeleteSecret} />
-              ))}
-            </TableBody>
-          </Table>
-        ) : (
-          <EmptyList>{t("pages.settings.secrets.list.empty")}</EmptyList>
+      <PaginationProvider items={filteredItems} pageSize={pageSize}>
+        {({
+          currentItems,
+          goToFirstPage,
+          goToPage,
+          goToNextPage,
+          goToPreviousPage,
+          currentPage,
+          pagesList,
+          totalPages,
+        }) => (
+          <>
+            <div className="mb-4 flex flex-col gap-4 sm:flex-row">
+              <h3 className="flex grow items-center gap-x-2 pb-2 pt-1 font-bold">
+                <SquareAsterisk className="h-5" />
+                {t("pages.settings.secrets.list.title")}
+              </h3>
+              <Input
+                className="sm:w-60"
+                value={search}
+                onChange={(e) => {
+                  setSearch(e.target.value);
+                  goToFirstPage();
+                }}
+                placeholder={t("pages.settings.secrets.list.searchPlaceholder")}
+              />
+              <CreateItemButton
+                data-testid="secret-create"
+                onClick={() => setCreateSecret(true)}
+              >
+                {t("pages.settings.secrets.list.createBtn")}
+              </CreateItemButton>
+            </div>
+            <Card className="mb-4">
+              {currentItems.length ? (
+                <Table>
+                  <TableBody>
+                    {currentItems.map((item, i) => (
+                      <ItemRow item={item} key={i} onDelete={setDeleteSecret} />
+                    ))}
+                  </TableBody>
+                </Table>
+              ) : (
+                <EmptyList>
+                  {t(
+                    isSearch
+                      ? "pages.settings.secrets.list.emptySearch"
+                      : "pages.settings.secrets.list.empty"
+                  )}
+                </EmptyList>
+              )}
+            </Card>
+            {totalPages > 1 && (
+              <Pagination>
+                <PaginationLink
+                  icon="left"
+                  onClick={() => goToPreviousPage()}
+                />
+                {pagesList.map((p) => (
+                  <PaginationLink
+                    active={currentPage === p}
+                    key={`${p}`}
+                    onClick={() => goToPage(p)}
+                  >
+                    {p}
+                  </PaginationLink>
+                ))}
+                <PaginationLink icon="right" onClick={() => goToNextPage()} />
+              </Pagination>
+            )}
+          </>
         )}
-        {deleteSecret && (
-          <Delete
-            name={deleteSecret.name}
-            onConfirm={() => deleteSecretMutation({ secret: deleteSecret })}
-          />
-        )}
-        {createSecret && <Create onSuccess={() => setDialogOpen(false)} />}
-      </Card>
+      </PaginationProvider>
+      {deleteSecret && (
+        <Delete
+          name={deleteSecret.name}
+          onConfirm={() => deleteSecretMutation({ secret: deleteSecret })}
+        />
+      )}
+      {createSecret && <Create onSuccess={() => setDialogOpen(false)} />}
     </Dialog>
   );
 };

--- a/src/pages/namespace/Settings/Secrets/index.tsx
+++ b/src/pages/namespace/Settings/Secrets/index.tsx
@@ -50,7 +50,9 @@ const SecretsList: FC = () => {
         <CreateItemButton
           data-testid="secret-create"
           onClick={() => setCreateSecret(true)}
-        />
+        >
+          {t("pages.settings.secrets.list.createBtn")}
+        </CreateItemButton>
       </div>
 
       <Card>

--- a/src/pages/namespace/Settings/Secrets/index.tsx
+++ b/src/pages/namespace/Settings/Secrets/index.tsx
@@ -114,13 +114,13 @@ const SecretsList: FC = () => {
                   icon="left"
                   onClick={() => goToPreviousPage()}
                 />
-                {pagesList.map((p) => (
+                {pagesList.map((page) => (
                   <PaginationLink
-                    active={currentPage === p}
-                    key={`${p}`}
-                    onClick={() => goToPage(p)}
+                    active={currentPage === page}
+                    key={`${page}`}
+                    onClick={() => goToPage(page)}
                   >
-                    {p}
+                    {page}
                   </PaginationLink>
                 ))}
                 <PaginationLink icon="right" onClick={() => goToNextPage()} />

--- a/src/pages/namespace/Settings/Variables/Create.tsx
+++ b/src/pages/namespace/Settings/Variables/Create.tsx
@@ -132,11 +132,7 @@ const Create = ({ onSuccess }: CreateProps) => {
               {t("components.button.label.cancel")}
             </Button>
           </DialogClose>
-          <Button
-            data-testid="variable-create-submit"
-            type="submit"
-            variant="primary"
-          >
+          <Button data-testid="variable-create-submit" type="submit">
             {t("components.button.label.create")}
           </Button>
         </DialogFooter>

--- a/src/pages/namespace/Settings/Variables/Edit.tsx
+++ b/src/pages/namespace/Settings/Variables/Edit.tsx
@@ -147,7 +147,7 @@ const Edit = ({ item, onSuccess }: EditProps) => {
               {t("components.button.label.cancel")}
             </Button>
           </DialogClose>
-          <Button type="submit" data-testid="var-edit-submit" variant="primary">
+          <Button type="submit" data-testid="var-edit-submit">
             {t("components.button.label.save")}
           </Button>
         </DialogFooter>

--- a/src/pages/namespace/Settings/Variables/index.tsx
+++ b/src/pages/namespace/Settings/Variables/index.tsx
@@ -67,28 +67,30 @@ const VariablesList: FC = () => {
           totalPages,
         }) => (
           <>
-            <div className="mb-3 flex flex-row gap-3">
+            <div className="mb-4 flex flex-col gap-4 sm:flex-row">
               <h3 className="flex grow items-center gap-x-2 pb-2 pt-1 font-bold">
                 <Braces className="h-5" />
                 {t("pages.settings.variables.list.title")}
               </h3>
-
               <Input
-                className="w-1/3"
+                className="sm:w-60"
                 value={search}
                 onChange={(e) => {
                   setSearch(e.target.value);
                   goToFirstPage();
                 }}
-                placeholder="search variables:"
+                placeholder={t(
+                  "pages.settings.variables.list.searchPlaceholder"
+                )}
               />
               <CreateItemButton
                 data-testid="variable-create"
                 onClick={() => setCreateItem(true)}
-              />
+              >
+                {t("pages.settings.variables.list.createBtn")}
+              </CreateItemButton>
             </div>
-
-            <Card className="mb-3">
+            <Card className="mb-4">
               {currentItems?.length ? (
                 <Table>
                   <TableBody>

--- a/src/pages/namespace/Settings/Variables/index.tsx
+++ b/src/pages/namespace/Settings/Variables/index.tsx
@@ -107,7 +107,7 @@ const VariablesList: FC = () => {
                 </EmptyList>
               )}
             </Card>
-            {totalPages > 2 && (
+            {totalPages > 1 && (
               <Pagination>
                 <PaginationLink
                   icon="left"

--- a/src/pages/namespace/Settings/Variables/index.tsx
+++ b/src/pages/namespace/Settings/Variables/index.tsx
@@ -30,11 +30,13 @@ const VariablesList: FC = () => {
   const isSearch = search.length > 0;
 
   const { data, isFetched } = useVars();
-  const items = data?.variables?.results ?? null;
 
   const filteredItems = useMemo(
-    () => items?.filter((item) => !isSearch || item.name.includes(search)),
-    [isSearch, items, search]
+    () =>
+      (data?.variables?.results ?? [])?.filter(
+        (item) => !isSearch || item.name.includes(search)
+      ),
+    [data?.variables?.results, isSearch, search]
   );
 
   const { mutate: deleteVarMutation } = useDeleteVar({
@@ -55,7 +57,7 @@ const VariablesList: FC = () => {
 
   return (
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-      <PaginationProvider items={filteredItems ?? []} pageSize={pageSize}>
+      <PaginationProvider items={filteredItems} pageSize={pageSize}>
         {({
           currentItems,
           goToFirstPage,
@@ -91,10 +93,10 @@ const VariablesList: FC = () => {
               </CreateItemButton>
             </div>
             <Card className="mb-4">
-              {currentItems?.length ? (
+              {currentItems.length ? (
                 <Table>
                   <TableBody>
-                    {currentItems?.map((item, i) => (
+                    {currentItems.map((item, i) => (
                       <ItemRow
                         item={item}
                         key={i}

--- a/src/pages/namespace/Settings/Variables/index.tsx
+++ b/src/pages/namespace/Settings/Variables/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect, useMemo, useState } from "react";
 import { Pagination, PaginationLink } from "~/design/Pagination";
 import { Table, TableBody } from "~/design/Table";
 
@@ -32,9 +32,9 @@ const VariablesList: FC = () => {
   const { data, isFetched } = useVars();
   const items = data?.variables?.results ?? null;
 
-  // wrap in useMemo
-  const filteredItems = items?.filter(
-    (item) => !isSearch || item.name.includes(search)
+  const filteredItems = useMemo(
+    () => items?.filter((item) => !isSearch || item.name.includes(search)),
+    [isSearch, items, search]
   );
 
   const { mutate: deleteVarMutation } = useDeleteVar({

--- a/src/pages/namespace/Settings/Variables/index.tsx
+++ b/src/pages/namespace/Settings/Variables/index.tsx
@@ -122,13 +122,13 @@ const VariablesList: FC = () => {
                   icon="left"
                   onClick={() => goToPreviousPage()}
                 />
-                {pagesList.map((p) => (
+                {pagesList.map((page) => (
                   <PaginationLink
-                    active={currentPage === p}
-                    key={`${p}`}
-                    onClick={() => goToPage(p)}
+                    active={currentPage === page}
+                    key={`${page}`}
+                    onClick={() => goToPage(page)}
                   >
-                    {p}
+                    {page}
                   </PaginationLink>
                 ))}
                 <PaginationLink icon="right" onClick={() => goToNextPage()} />

--- a/src/pages/namespace/Settings/Variables/index.tsx
+++ b/src/pages/namespace/Settings/Variables/index.tsx
@@ -27,13 +27,14 @@ const VariablesList: FC = () => {
   const [editItem, setEditItem] = useState<VarSchemaType>();
   const [createItem, setCreateItem] = useState(false);
   const [search, setSearch] = useState("");
+  const isSearch = search.length > 0;
 
   const { data, isFetched } = useVars();
   const items = data?.variables?.results ?? null;
 
   // wrap in useMemo
   const filteredItems = items?.filter(
-    (item) => !search || item.name.includes(search)
+    (item) => !isSearch || item.name.includes(search)
   );
 
   const { mutate: deleteVarMutation } = useDeleteVar({
@@ -103,7 +104,11 @@ const VariablesList: FC = () => {
                 </Table>
               ) : (
                 <EmptyList>
-                  {t("pages.settings.variables.list.empty")}
+                  {t(
+                    isSearch
+                      ? "pages.settings.variables.list.emptySearch"
+                      : "pages.settings.variables.list.empty"
+                  )}
                 </EmptyList>
               )}
             </Card>

--- a/src/pages/namespace/Settings/components/CreateItemButton.tsx
+++ b/src/pages/namespace/Settings/components/CreateItemButton.tsx
@@ -3,10 +3,14 @@ import { ComponentPropsWithoutRef } from "react";
 import { DialogTrigger } from "~/design/Dialog";
 import { PlusCircle } from "lucide-react";
 
-const CreateItemButton = (props: ComponentPropsWithoutRef<"button">) => (
+const CreateItemButton = ({
+  children,
+  ...props
+}: ComponentPropsWithoutRef<"button">) => (
   <DialogTrigger {...props} asChild>
     <Button variant="outline">
       <PlusCircle />
+      {children}
     </Button>
   </DialogTrigger>
 );


### PR DESCRIPTION

**[Preview 🚀](https://direktiv-ui-refs-pull-443-merge.direktiv.dev/)**

This PR adds a client side search to secrets, registries and variables ![CleanShot 2023-08-10 at 15 08 02@2x](https://github.com/direktiv/direktiv-ui/assets/121789579/a022fc3f-511a-4018-b8ec-0d4add991151)

- Made header of secrets, registries and variables responsive
- I changed every "+" Button to be like "+ Create Variable". It looks better on mobile, because the button is much bigger. And I even like it better to very explicit, and it also matches "+ send new event" button on the new events page ![CleanShot 2023-08-10 at 14 25 04@2x](https://github.com/direktiv/direktiv-ui/assets/121789579/d10aea1b-60ff-49b4-92d1-d1ef06fc6cf9)
- Changed modal button from primary variant to default variant. I noticed that we never use a primary button in a modal elsewhere. I'm open to change that in the future but I remove the primary variant for now, just for consistency


## Follow up tickets
- [E2E tests](https://linear.app/direktiv/issue/DIR-738/pagination-and-filter-on-the-settingspage)