### PR TITLE
[DIR-622] test registry credentials

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -329,7 +329,7 @@
           "user": "User",
           "password": "Password",
           "testConnectionBtn": {
-            "label": "Test Connection",
+            "label": "Test connection",
             "success": "Connection successful",
             "error": "Connection failed"
           }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -327,7 +327,8 @@
           "description": "Add a container registry",
           "url": "URL",
           "user": "User",
-          "password": "Password"
+          "password": "Password",
+          "testConnectionBtn": "Test Connection"
         }
       },
       "variables": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -328,7 +328,11 @@
           "url": "URL",
           "user": "User",
           "password": "Password",
-          "testConnectionBtn": "Test Connection"
+          "testConnectionBtn": {
+            "label": "Test Connection",
+            "success": "Connection successful",
+            "error": "Connection failed"
+          }
         }
       },
       "variables": {

--- a/src/api/registries/mutate/testConnection.ts
+++ b/src/api/registries/mutate/testConnection.ts
@@ -1,0 +1,50 @@
+import { RegistryTestConnectionSchema } from "../schema";
+import { apiFactory } from "~/api/apiFactory";
+import { useApiKey } from "~/util/store/apiKey";
+import { useMutation } from "@tanstack/react-query";
+import { useNamespace } from "~/util/store/namespace";
+
+export const testConnection = apiFactory({
+  url: ({ baseUrl }: { baseUrl?: string }) =>
+    `${baseUrl ?? ""}/api/functions/registries/test`,
+  method: "POST",
+  schema: RegistryTestConnectionSchema,
+});
+
+export const useTestConnection = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: () => void;
+  onError?: () => void;
+} = {}) => {
+  const apiKey = useApiKey();
+  const namespace = useNamespace();
+
+  if (!namespace) {
+    throw new Error("namespace is undefined");
+  }
+
+  return useMutation({
+    mutationFn: ({
+      url,
+      username,
+      password,
+    }: {
+      url: string;
+      username: string;
+      password: string;
+    }) =>
+      testConnection({
+        apiKey: apiKey ?? undefined,
+        urlParams: {},
+        payload: { url, username, password },
+      }),
+    onSuccess: () => {
+      onSuccess?.();
+    },
+    onError: () => {
+      onError?.();
+    },
+  });
+};

--- a/src/api/registries/schema.ts
+++ b/src/api/registries/schema.ts
@@ -22,6 +22,8 @@ export const RegistryListSchema = z.object({
   registries: z.array(RegistrySchema),
 });
 
+export const RegistryTestConnectionSchema = z.null();
+
 export const RegistryCreatedSchema = z.null();
 
 export const RegistryDeletedSchema = z.null();

--- a/src/api/registries/schema.ts
+++ b/src/api/registries/schema.ts
@@ -22,7 +22,7 @@ export const RegistryListSchema = z.object({
   registries: z.array(RegistrySchema),
 });
 
-export const RegistryTestConnectionSchema = z.null();
+export const RegistryTestConnectionSchema = z.object({});
 
 export const RegistryCreatedSchema = z.null();
 

--- a/src/pages/namespace/Settings/Registries/Create/TestConnectionButton.tsx
+++ b/src/pages/namespace/Settings/Registries/Create/TestConnectionButton.tsx
@@ -1,0 +1,72 @@
+import { CheckCircle2, CircleDashed, XCircle } from "lucide-react";
+import { ComponentProps, FC, useEffect, useState } from "react";
+
+import Button from "~/design/Button";
+import { useTestConnection } from "~/api/registries/mutate/testConnection";
+import { useTranslation } from "react-i18next";
+
+export const TestConnectionButton = ({
+  isValid,
+  getValues,
+}: {
+  isValid: boolean;
+  getValues: (name: "url" | "user" | "password") => string;
+}) => {
+  const { t } = useTranslation();
+  const [testSuccessful, setTestSuccessful] = useState<boolean | null>(null); // null = not tested yet
+
+  useEffect(() => {
+    // reset test status after 3 seconds
+    if (testSuccessful !== null) {
+      const timeout = setTimeout(() => {
+        setTestSuccessful(null);
+      }, 3000);
+      return () => clearTimeout(timeout);
+    }
+  }, [testSuccessful]);
+
+  const { mutate: testConnection, isLoading } = useTestConnection({
+    onSuccess: () => {
+      setTestSuccessful(true);
+    },
+    onError: () => {
+      setTestSuccessful(false);
+    },
+  });
+
+  const onTestConnectionClick = () => {
+    testConnection({
+      url: getValues("url"),
+      username: getValues("user"),
+      password: getValues("password"),
+    });
+  };
+
+  let variant: ComponentProps<typeof Button>["variant"] = "outline";
+  let Icon: FC<React.SVGProps<SVGSVGElement>> = CircleDashed;
+  let label = t("pages.settings.registries.create.testConnectionBtn.label");
+
+  if (testSuccessful === true) {
+    variant = "primary";
+    Icon = CheckCircle2;
+    label = t("pages.settings.registries.create.testConnectionBtn.success");
+  }
+  if (testSuccessful === false) {
+    variant = "destructive";
+    Icon = XCircle;
+    label = t("pages.settings.registries.create.testConnectionBtn.error");
+  }
+
+  return (
+    <Button
+      onClick={onTestConnectionClick}
+      loading={isLoading}
+      disabled={!isValid || isLoading}
+      type="button"
+      variant={variant}
+    >
+      {!isLoading && <Icon />}
+      {label}
+    </Button>
+  );
+};

--- a/src/pages/namespace/Settings/Registries/Create/index.tsx
+++ b/src/pages/namespace/Settings/Registries/Create/index.tsx
@@ -1,5 +1,3 @@
-import { CheckCircle2, CircleDashed, PlusCircle, XCircle } from "lucide-react";
-import { ComponentProps, FC, useState } from "react";
 import {
   DialogClose,
   DialogContent,
@@ -16,63 +14,17 @@ import { SubmitHandler, useForm } from "react-hook-form";
 import Button from "~/design/Button";
 import FormErrors from "~/componentsNext/FormErrors";
 import Input from "~/design/Input";
+import { PlusCircle } from "lucide-react";
+import { TestConnectionButton } from "./TestConnectionButton";
 import { useCreateRegistry } from "~/api/registries/mutate/createRegistry";
-import { useTestConnection } from "~/api/registries/mutate/testConnection";
 import { useTranslation } from "react-i18next";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 type CreateProps = { onSuccess: () => void };
 
-type ConnectionTestSuccessfull = boolean | null; // null = not tested yet
-type ButtonVariants = ComponentProps<typeof Button>["variant"];
-
-const useConnectionButtonState = (
-  testSuccessful: ConnectionTestSuccessfull
-): {
-  variant: ButtonVariants;
-  icon: FC<React.SVGProps<SVGSVGElement>>;
-  label: string;
-} => {
-  const { t } = useTranslation();
-  let variant: ButtonVariants = "outline";
-  let icon: FC<React.SVGProps<SVGSVGElement>> = CircleDashed;
-
-  let label = t("pages.settings.registries.create.testConnectionBtn.label");
-
-  if (testSuccessful === true) {
-    variant = "primary";
-    icon = CheckCircle2;
-    label = t("pages.settings.registries.create.testConnectionBtn.success");
-  }
-  if (testSuccessful === false) {
-    variant = "destructive";
-    icon = XCircle;
-    label = t("pages.settings.registries.create.testConnectionBtn.error");
-  }
-
-  return {
-    variant,
-    icon,
-    label,
-  };
-};
-
 const Create = ({ onSuccess }: CreateProps) => {
   const { t } = useTranslation();
   const { mutate: createRegistryMutation } = useCreateRegistry({ onSuccess });
-  const [testSuccessful, setTestSuccessful] =
-    useState<ConnectionTestSuccessfull>(null);
-
-  const connectionButtonState = useConnectionButtonState(testSuccessful);
-
-  const { mutate: testConnection, isLoading: testLoading } = useTestConnection({
-    onSuccess: () => {
-      setTestSuccessful(true);
-    },
-    onError: () => {
-      setTestSuccessful(false);
-    },
-  });
 
   const onSubmit: SubmitHandler<RegistryFormSchemaType> = (data) => {
     createRegistryMutation(data);
@@ -86,14 +38,6 @@ const Create = ({ onSuccess }: CreateProps) => {
   } = useForm<RegistryFormSchemaType>({
     resolver: zodResolver(RegistryFormSchema),
   });
-
-  const onTestConnectionClick = () => {
-    testConnection({
-      url: getValues("url"),
-      username: getValues("user"),
-      password: getValues("password"),
-    });
-  };
 
   return (
     <DialogContent>
@@ -150,17 +94,7 @@ const Create = ({ onSuccess }: CreateProps) => {
               {t("components.button.label.cancel")}
             </Button>
           </DialogClose>
-          <Button
-            data-testid="registry-create-test-connection"
-            onClick={onTestConnectionClick}
-            loading={testLoading}
-            disabled={!isValid || testLoading}
-            type="button"
-            variant={connectionButtonState.variant}
-          >
-            {!testLoading && <connectionButtonState.icon />}
-            {connectionButtonState.label}
-          </Button>
+          <TestConnectionButton getValues={getValues} isValid={isValid} />
           <Button data-testid="registry-create-submit" type="submit">
             {t("components.button.label.create")}
           </Button>


### PR DESCRIPTION
This PR is an add-on to [this PR](https://github.com/direktiv/direktiv-ui/pull/443) to avoid merge conflicts. It implements the Test Connection Button on the registry page.

**[Preview 🚀](https://direktiv-ui-refs-pull-445-merge.direktiv.dev/)**

https://github.com/direktiv/direktiv-ui/assets/121789579/c04592d4-833d-4faf-914c-2153bd40b9ba

While developing this feature, I found out that the API behind this button is more a validation and not a real connection test (e.g. any url starting with https://hub.docker.com passes the connection test, username and password does not seem to matter). We should discuss, whether we should just mimic this behavior on the client and make this a real validation and not implying to check the credentials and the actual existent of the repo.

## Follow up tickets
- [E2E-Tests](https://linear.app/direktiv/issue/DIR-742/test-connection-button-when-adding-a-registry)
