### PR TITLE
[DIR-209] set live status on workflow

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -172,10 +172,10 @@
         },
         "headline": "Latest",
         "updated": "Updated {{relativeTime}} ago",
-        "runBtn": {
-          "runWorkflow": "Run",
-          "setActive": "Set active",
-          "setInactive": "Set inactive"
+        "runBtn": "Run",
+        "toggleActiveBtn": {
+          "setActive": "Activate workflow",
+          "setInactive": "Deactivate workflow"
         },
         "editor": {
           "unsavedNote": "unsaved changes",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -169,7 +169,11 @@
         },
         "headline": "Latest",
         "updated": "Updated {{relativeTime}} ago",
-        "runBtn": "Run",
+        "runBtn": {
+          "runWorkflow": "Run",
+          "setActive": "Set active",
+          "setInactive": "Set inactive"
+        },
         "editor": {
           "unsavedNote": "unsaved changes",
           "theresOneIssue": "There is an issue",
@@ -630,6 +634,15 @@
           },
           "error": {
             "description": "could not save workflow variable 😢"
+          }
+        },
+        "toggleLive": {
+          "success": {
+            "title": "Workflow updated",
+            "description": {
+              "activated": "Workflow {{workflow}} was activated",
+              "deactivated": "Workflow {{workflow}} was deactivated"
+            }
           }
         },
         "createDirectory": {

--- a/src/api/tree/mutate/toggleLive.ts
+++ b/src/api/tree/mutate/toggleLive.ts
@@ -1,0 +1,68 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { ToggleLiveSchema } from "../schema";
+import { apiFactory } from "~/api/apiFactory";
+import { forceLeadingSlash } from "../utils";
+import { treeKeys } from "..";
+import { useApiKey } from "~/util/store/apiKey";
+import { useNamespace } from "~/util/store/namespace";
+import { useToast } from "~/design/Toast";
+import { useTranslation } from "react-i18next";
+
+const toggleLive = apiFactory({
+  url: ({ namespace, path }: { namespace: string; path: string }) =>
+    `/api/namespaces/${namespace}/tree${forceLeadingSlash(path)}?op=toggle`,
+  method: "POST",
+  schema: ToggleLiveSchema,
+});
+
+export const useToggleLive = ({
+  onSuccess,
+}: {
+  onSuccess?: (data: null) => void;
+} = {}) => {
+  const apiKey = useApiKey();
+  const namespace = useNamespace();
+  const { toast } = useToast();
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  if (!namespace) {
+    throw new Error("namespace is undefined");
+  }
+
+  const mutationFn = ({ path, value }: { path: string; value: boolean }) =>
+    toggleLive({
+      apiKey: apiKey ?? undefined,
+      payload: { live: value },
+      urlParams: {
+        namespace,
+        path,
+      },
+    });
+
+  return useMutation({
+    mutationFn,
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries(
+        treeKeys.router(namespace, {
+          apiKey: apiKey ?? undefined,
+          path: variables.path,
+        })
+      );
+      onSuccess?.(data);
+      const statusKey = variables.value ? "activated" : "deactivated";
+      toast({
+        title: t("api.tree.mutate.toggleLive.success.title"),
+        description: t(
+          `api.tree.mutate.toggleLive.success.description.${statusKey}`,
+          {
+            workflow: variables.path,
+            status: variables.value,
+          }
+        ),
+        variant: "success",
+      });
+    },
+  });
+};

--- a/src/api/tree/schema.ts
+++ b/src/api/tree/schema.ts
@@ -62,6 +62,8 @@ export const RouterSchema = z.object({
     .refine((routes) => [0, 2].includes(routes.length)),
 });
 
+export const ToggleLiveSchema = z.null();
+
 export const FolderCreatedSchema = z.object({
   namespace: z.string(),
   node: NodeSchema,

--- a/src/pages/namespace/Explorer/Workflow/index.tsx
+++ b/src/pages/namespace/Explorer/Workflow/index.tsx
@@ -1,5 +1,5 @@
+import { Dialog, DialogContent, DialogTrigger } from "~/design/Dialog";
 import {
-  ChevronDown,
   GitCommit,
   GitMerge,
   PieChart,
@@ -8,18 +8,16 @@ import {
   PowerOff,
   Settings,
 } from "lucide-react";
-import { Dialog, DialogContent, DialogTrigger } from "~/design/Dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "~/design/Dropdown";
 import { Link, Outlet } from "react-router-dom";
 import { Tabs, TabsList, TabsTrigger } from "~/design/Tabs";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "~/design/Tooltip";
 
 import Button from "~/design/Button";
-import { ButtonBar } from "~/design/ButtonBar";
 import { FC } from "react";
 import RunWorkflow from "./components/RunWorkflow";
 import { analyzePath } from "~/util/router/utils";
@@ -109,54 +107,43 @@ const Header: FC = () => {
             <Play className="h-5" />
             {filename?.relative}
           </h3>
-
-          <Dialog>
-            <ButtonBar>
+          <div className="flex gap-x-3">
+            <TooltipProvider>
+              <Button
+                loading={!routerIsFetched}
+                icon
+                variant="outline"
+                onClick={() => toggleLive({ path, value: !isLive })}
+              >
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    {routerIsFetched && (isLive ? <PowerOff /> : <Power />)}
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {isLive
+                      ? t("pages.explorer.workflow.toggleActiveBtn.setInactive")
+                      : t("pages.explorer.workflow.toggleActiveBtn.setActive")}
+                  </TooltipContent>
+                </Tooltip>
+              </Button>
+            </TooltipProvider>
+            <Dialog>
               <DialogTrigger asChild>
                 <Button
-                  loading={!routerIsFetched}
-                  disabled={!isLive}
                   variant="primary"
+                  disabled={!isLive}
                   data-testid="workflow-header-btn-run"
                 >
-                  {routerIsFetched && <Play />}
-                  {t("pages.explorer.workflow.runBtn.runWorkflow")}
+                  <Play />
+                  {t("pages.explorer.workflow.runBtn")}
                 </Button>
               </DialogTrigger>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant={isLive ? "primary" : "outline"}
-                    disabled={!routerIsFetched}
-                    loading={!routerIsFetched}
-                  >
-                    {routerIsFetched && <ChevronDown />}
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent>
-                  <DropdownMenuItem
-                    onClick={() => toggleLive({ path, value: !isLive })}
-                  >
-                    {isLive ? (
-                      <>
-                        <PowerOff className="mr-2 h-4 w-4" />
-                        {t("pages.explorer.workflow.runBtn.setInactive")}
-                      </>
-                    ) : (
-                      <>
-                        <Power className="mr-2 h-4 w-4" />
-                        {t("pages.explorer.workflow.runBtn.setActive")}
-                      </>
-                    )}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </ButtonBar>
 
-            <DialogContent className="sm:max-w-2xl">
-              <RunWorkflow path={path} />
-            </DialogContent>
-          </Dialog>
+              <DialogContent className="sm:max-w-2xl">
+                <RunWorkflow path={path} />
+              </DialogContent>
+            </Dialog>
+          </div>
         </div>
         <div>
           <nav className="-mb-px flex space-x-8">


### PR DESCRIPTION
[Preview](https://direktiv-ui-refs-pull-448-merge.direktiv.dev/)

This adds the ability to turn the workflow active / inactive.

It's implemented on top of the branch for the workflow settings page in PR #447.

I made the dropdown trigger variant="primary" as well, but that doesn't look good when the main button is inactive:

![image](https://github.com/direktiv/direktiv-ui/assets/129740294/3fe6d479-d7f3-4298-b9ec-d1ef772ccd32)

So I changed the dropdown trigger to "outline", but only when the other button is inactive. It's not 100% logical to have the dropdown button active in the second example, but that way it blends in naturally with the main button.

![image](https://github.com/direktiv/direktiv-ui/assets/129740294/74e6786b-e340-444a-8fb0-cebc0dad2780)
![image](https://github.com/direktiv/direktiv-ui/assets/129740294/c6474eea-1558-4ed1-812f-53dd3bdf7c27)

* [x] should we add a tooltip to the button when the workflow is inactive? I think the button is already pretty self-explanatory (at least when you investigate and click on the dropdown)

