### PR TITLE
[DIR-817] disable the run button when the the editor has unsaved changes

### DIFF
--- a/e2e/explorer/workflow/run.spec.ts
+++ b/e2e/explorer/workflow/run.spec.ts
@@ -167,6 +167,29 @@ test("it is possible to run the workflow by setting an input JSON via the editor
   ).toBe(userInputString);
 });
 
+test("it is not possible to run the workflow when the editor has unsaved changes", async ({
+  page,
+}) => {
+  const workflowName = faker.system.commonFileName("yaml");
+  await createWorkflow({
+    payload: basicWorkflow.data,
+    urlParams: {
+      baseUrl: process.env.VITE_DEV_API_DOMAIN,
+      namespace,
+      name: workflowName,
+    },
+    headers,
+  });
+
+  await page.goto(`${namespace}/explorer/workflow/active/${workflowName}`);
+
+  await expect(page.getByTestId("workflow-editor-btn-run")).not.toBeDisabled();
+
+  await page.type("textarea", faker.random.alphaNumeric(9));
+
+  await expect(page.getByTestId("workflow-editor-btn-run")).toBeDisabled();
+});
+
 test("it is possible to provide the input via generated form", async ({
   page,
 }) => {

--- a/src/pages/namespace/Explorer/Workflow/Active/WorkflowEditor.tsx
+++ b/src/pages/namespace/Explorer/Workflow/Active/WorkflowEditor.tsx
@@ -139,7 +139,11 @@ const WorkflowEditor: FC<{
         </DropdownMenu>
         <Dialog>
           <DialogTrigger asChild>
-            <Button variant="outline" data-testid="workflow-editor-btn-run">
+            <Button
+              variant="outline"
+              data-testid="workflow-editor-btn-run"
+              disabled={hasUnsavedChanges}
+            >
               <Play />
               {t("pages.explorer.workflow.editor.runBtn")}
             </Button>

--- a/src/pages/namespace/Services/Detail/Create.tsx
+++ b/src/pages/namespace/Services/Detail/Create.tsx
@@ -54,7 +54,6 @@ const CreateRevision = ({
     register,
     handleSubmit,
     watch,
-    getValues,
     setValue,
     formState: { errors },
   } = useForm<RevisionFormSchemaType>({

--- a/src/pages/namespace/Services/List/Create.tsx
+++ b/src/pages/namespace/Services/List/Create.tsx
@@ -50,7 +50,6 @@ const CreateService = ({
     register,
     handleSubmit,
     watch,
-    getValues,
     setValue,
     formState: { isDirty, errors, isValid, isSubmitted },
   } = useForm<ServiceFormSchemaType>({


### PR DESCRIPTION
This PR will disable the run button when the editor has unsaved changes.

https://github.com/direktiv/direktiv-ui/assets/121789579/74bdaa68-8d98-4c31-80fe-74a03d88cb19

### The problem
Running a workflow when the user has unsaved changes can create problems. The user may not even be aware that their changes haven't been saved. For example, if the user attempts to save their work but encounters a syntax error, the changes will not be saved at that moment. If the user doesn't notice the error and proceeds to run the workflow, it will execute in an unexpected state. Additionally, all previous changes that were not saved will be lost.