### PR TITLE
[DIR-821] reverse mirror activities

### DIFF
--- a/src/api/tree/query/mirrorInfo.ts
+++ b/src/api/tree/query/mirrorInfo.ts
@@ -23,6 +23,8 @@ const fetchMirrorInfo = async ({
     ...res,
     activities: {
       ...res.activities,
+      // This should be changed in the backend in [DIR-833]
+      // reverse the order of activities (newer first)
       results: [...(res.activities.results ?? []).reverse()],
     },
   }));

--- a/src/api/tree/query/mirrorInfo.ts
+++ b/src/api/tree/query/mirrorInfo.ts
@@ -19,7 +19,13 @@ const fetchMirrorInfo = async ({
   getMirrorInfo({
     apiKey,
     urlParams: { namespace },
-  });
+  }).then((res) => ({
+    ...res,
+    activities: {
+      ...res.activities,
+      results: [...(res.activities.results ?? []).reverse()],
+    },
+  }));
 
 export const useMirrorInfo = () => {
   const apiKey = useApiKey();

--- a/src/pages/namespace/Services/Detail/Create.tsx
+++ b/src/pages/namespace/Services/Detail/Create.tsx
@@ -54,7 +54,6 @@ const CreateRevision = ({
     register,
     handleSubmit,
     watch,
-    getValues,
     setValue,
     formState: { errors },
   } = useForm<RevisionFormSchemaType>({

--- a/src/pages/namespace/Services/List/Create.tsx
+++ b/src/pages/namespace/Services/List/Create.tsx
@@ -50,7 +50,6 @@ const CreateService = ({
     register,
     handleSubmit,
     watch,
-    getValues,
     setValue,
     formState: { isDirty, errors, isValid, isSubmitted },
   } = useForm<ServiceFormSchemaType>({


### PR DESCRIPTION
This PR will reverse the order of the mirror activities to make the newest appear on top. 

Before:

https://github.com/direktiv/direktiv-ui/assets/121789579/8994eae6-b994-4dfb-a420-36240e7383fa



After:

https://github.com/direktiv/direktiv-ui/assets/121789579/8b95ce28-dc8d-4de0-b095-d6dbbeb31f0b



--- 
Follow-up ticket
- [DIR-833: This behavior should be handled by the backend](https://linear.app/direktiv/issue/DIR-833/reverse-the-order-of-mirror-activities)
