### PR TITLE
[DIR-843] Deleting last namespace behaviour is incorrect

### DIFF
--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -84,7 +84,7 @@ const Layout = () => {
   // wait until namespaces are fetched to avoid layout shifts
   // either the useEffect will redirect or the onboarding screen
   // will be shown
-  if (!isFetched || isRefetching) {
+  if (!isFetched) {
     return null;
   }
 

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -13,11 +13,7 @@ import { useTranslation } from "react-i18next";
 
 const Layout = () => {
   const { t } = useTranslation();
-  const {
-    data: availableNamespaces,
-    isFetched,
-    isRefetching,
-  } = useListNamespaces();
+  const { data: availableNamespaces, isRefetching } = useListNamespaces();
   const activeNamespace = useNamespace();
   const { setNamespace } = useNamespaceActions();
   const [, setDialogOpen] = useState(false);
@@ -80,13 +76,6 @@ const Layout = () => {
     navigate,
     setNamespace,
   ]);
-
-  // wait until namespaces are fetched to avoid layout shifts
-  // either the useEffect will redirect or the onboarding screen
-  // will be shown
-  if (!isFetched || isRefetching) {
-    return null;
-  }
 
   return (
     <main className="grid min-h-full place-items-center py-24 px-6 sm:py-32 lg:px-8">

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -13,7 +13,11 @@ import { useTranslation } from "react-i18next";
 
 const Layout = () => {
   const { t } = useTranslation();
-  const { data: availableNamespaces, isFetched } = useListNamespaces();
+  const {
+    data: availableNamespaces,
+    isFetched,
+    isRefetching,
+  } = useListNamespaces();
   const activeNamespace = useNamespace();
   const { setNamespace } = useNamespaceActions();
   const [, setDialogOpen] = useState(false);
@@ -42,7 +46,16 @@ const Layout = () => {
   ];
 
   useEffect(() => {
-    if (availableNamespaces && availableNamespaces.results[0]) {
+    if (
+      availableNamespaces &&
+      availableNamespaces.results[0] &&
+      /**
+       * the namespace list might still be refetching after a cache invalidation. This could be caused by a
+       * namespace delete action that was just triggered. We have to wait until the refetch is done to avoid
+       * using an old namespaces list.
+       */
+      !isRefetching
+    ) {
       // if there is a prefered namespace in localStorage, redirect to it
       if (
         activeNamespace &&
@@ -60,12 +73,18 @@ const Layout = () => {
       );
       return;
     }
-  }, [activeNamespace, availableNamespaces, navigate, setNamespace]);
+  }, [
+    activeNamespace,
+    availableNamespaces,
+    isRefetching,
+    navigate,
+    setNamespace,
+  ]);
 
   // wait until namespaces are fetched to avoid layout shifts
   // either the useEffect will redirect or the onboarding screen
   // will be shown
-  if (!isFetched) {
+  if (!isFetched || isRefetching) {
     return null;
   }
 

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -13,7 +13,11 @@ import { useTranslation } from "react-i18next";
 
 const Layout = () => {
   const { t } = useTranslation();
-  const { data: availableNamespaces, isRefetching } = useListNamespaces();
+  const {
+    data: availableNamespaces,
+    isFetched,
+    isRefetching,
+  } = useListNamespaces();
   const activeNamespace = useNamespace();
   const { setNamespace } = useNamespaceActions();
   const [, setDialogOpen] = useState(false);
@@ -76,6 +80,13 @@ const Layout = () => {
     navigate,
     setNamespace,
   ]);
+
+  // wait until namespaces are fetched to avoid layout shifts
+  // either the useEffect will redirect or the onboarding screen
+  // will be shown
+  if (!isFetched || isRefetching) {
+    return null;
+  }
 
   return (
     <main className="grid min-h-full place-items-center py-24 px-6 sm:py-32 lg:px-8">


### PR DESCRIPTION
Description from the ticket

> If I delete the last namespace the UI stays on the namespace UI. It even shows in the breadcrumb but it should go to the "create namespace" page.

## What happened?

- In `src/api/namespaces/mutate/deleteNamespace.ts`, in the `onSuccess` callback we invalidate the namespaces list after the namespace was deleted. 
- The user will then be redirected to the landingpage (this is triggred in line `38` in `src/pages/namespace/Settings/DeleteNamespace/Delete.tsx`)
- On the landingpage, a `useEffect` will see that there are some namespaces in the store and redirect to the first one (because localstorage has no prefered namespace stored after the delete action)


## The bug
- We invalidate the cache when a namespace is deleted, which triggered a refetch
- When the `useEffect` on the landing page runs, this request might still be ongoing and we just use the old cached namespaces list, just a moment before it gets updated
-  the solution was to use `isRefetching` to detect the refetching state and wait for it to be false 
-  this bug is hard to detect, because in most cases the stale list of namespaces works good enough if the first one in this list is not the one we just deleted. When we deleted the last namespace, this is always the case. 


@sebxian I fixed this bug without actually trying to delete the last namespace (I did not want to delete all namespaces from our preview server). It would be great if you could test this on your local machine, if possible.

