### PR TITLE
[DIR-814] Fix "Open workflow" button on instances page (was bugged in production only)

### DIFF
--- a/src/design/Button/index.tsx
+++ b/src/design/Button/index.tsx
@@ -4,6 +4,7 @@ import { Loader2 } from "lucide-react";
 import { Slot } from "@radix-ui/react-slot";
 import { twMergeClsx } from "~/util/helpers";
 
+// asChild only works with exactly one child, so when asChild is true, we can not have a loading property
 type AsChildOrLoading =
   | {
       loading?: boolean;

--- a/src/design/Button/index.tsx
+++ b/src/design/Button/index.tsx
@@ -3,17 +3,19 @@ import * as React from "react";
 import { Loader2 } from "lucide-react";
 import { Slot } from "@radix-ui/react-slot";
 import { twMergeClsx } from "~/util/helpers";
-import { z } from "zod";
 
-const isLinkComponent = (children: React.ReactNode) => {
-  const validatedChildren = z
-    .object({ type: z.object({ displayName: z.string() }) })
-    .safeParse(children);
-  return (
-    validatedChildren.success &&
-    validatedChildren.data.type.displayName === "Link"
-  );
-};
+// See comment below resp. DIR-814
+// import { z } from "zod";
+
+// const isLinkComponent = (children: React.ReactNode) => {
+//   const validatedChildren = z
+//     .object({ type: z.object({ displayName: z.string() }) })
+//     .safeParse(children);
+//   return (
+//     validatedChildren.success &&
+//     validatedChildren.data.type.displayName === "Link"
+//   );
+// };
 
 // asChild only works with exactly one child, so when asChild is true, we can not have a loading property
 type AsChildOrLoading =
@@ -32,6 +34,7 @@ export type ButtonProps = {
   circle?: boolean;
   block?: boolean;
   icon?: boolean;
+  isAnchor?: boolean;
 } & AsChildOrLoading;
 
 const Button = React.forwardRef<
@@ -50,16 +53,19 @@ const Button = React.forwardRef<
       loading,
       icon,
       asChild,
+      isAnchor = false,
       ...props
     },
     ref
   ) => {
     const Comp = asChild ? Slot : "button";
-    const isAnchor = React.Children.toArray(children).some(
-      (child) =>
-        React.isValidElement(child) &&
-        (child.type === "a" || isLinkComponent(child))
-    );
+    // see comments in DIR-814.
+    // This check isn't reliable in production. As a quick bug fix, "isAnchor" is declared manually.
+    // const isAnchor = React.Children.toArray(children).some(
+    //   (child) =>
+    //     React.isValidElement(child) &&
+    //     (child.type === "a" || isLinkComponent(child))
+    // );
     // In case of asChild, if a child is not an anchor(e.g, label, span, etc) we are going to remove th click & hover effect
     const childIsNotAnAnchor = asChild && !isAnchor;
 

--- a/src/design/Button/index.tsx
+++ b/src/design/Button/index.tsx
@@ -4,20 +4,6 @@ import { Loader2 } from "lucide-react";
 import { Slot } from "@radix-ui/react-slot";
 import { twMergeClsx } from "~/util/helpers";
 
-// See comment below resp. DIR-814
-// import { z } from "zod";
-
-// const isLinkComponent = (children: React.ReactNode) => {
-//   const validatedChildren = z
-//     .object({ type: z.object({ displayName: z.string() }) })
-//     .safeParse(children);
-//   return (
-//     validatedChildren.success &&
-//     validatedChildren.data.type.displayName === "Link"
-//   );
-// };
-
-// asChild only works with exactly one child, so when asChild is true, we can not have a loading property
 type AsChildOrLoading =
   | {
       loading?: boolean;
@@ -59,13 +45,7 @@ const Button = React.forwardRef<
     ref
   ) => {
     const Comp = asChild ? Slot : "button";
-    // see comments in DIR-814.
-    // This check isn't reliable in production. As a quick bug fix, "isAnchor" is declared manually.
-    // const isAnchor = React.Children.toArray(children).some(
-    //   (child) =>
-    //     React.isValidElement(child) &&
-    //     (child.type === "a" || isLinkComponent(child))
-    // );
+
     // In case of asChild, if a child is not an anchor(e.g, label, span, etc) we are going to remove th click & hover effect
     const childIsNotAnAnchor = asChild && !isAnchor;
 

--- a/src/pages/namespace/Explorer/Workflow/Revisions/Detail/index.tsx
+++ b/src/pages/namespace/Explorer/Workflow/Revisions/Detail/index.tsx
@@ -89,7 +89,7 @@ const WorkflowRevisionsPage = () => {
 
       <div className="flex flex-col justify-end gap-4 sm:flex-row sm:items-center">
         <EditorLayoutSwitcher />
-        <Button asChild variant="outline">
+        <Button asChild isAnchor variant="outline">
           <Link
             data-testid="revisions-detail-back-link"
             to={pages.explorer.createHref({

--- a/src/pages/namespace/Instances/Detail/Header/index.tsx
+++ b/src/pages/namespace/Instances/Detail/Header/index.tsx
@@ -98,7 +98,7 @@ const Header = () => {
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
-          <Button asChild variant="primary" className="max-md:w-full">
+          <Button asChild isAnchor variant="primary" className="max-md:w-full">
             <Link to={link}>
               <FileSymlink />
               {t("pages.instances.detail.header.openWorkflow")}

--- a/src/util/router/pages.tsx
+++ b/src/util/router/pages.tsx
@@ -340,9 +340,10 @@ export const pages: PageType & EnterprisePageType = {
 
       const subpage = params.subpage ? subfolder[params.subpage] : "tree";
 
-      return `/${
-        params.namespace
-      }/explorer/${subpage}${path}?${searchParams.toString()}`;
+      const searchParamsString = searchParams.toString();
+      const urlParams = searchParamsString ? `?${searchParamsString}` : "";
+
+      return `/${params.namespace}/explorer/${subpage}${path}${urlParams}`;
     },
     useParams: () => {
       const { "*": path, namespace } = useParams();


### PR DESCRIPTION
See DIR-814 for details.

This fixes a bug that only appeared in production, where the "Open workflow" button on the instances detail page didn't work. In development mode, there was no issue with the button.

I removed (commented) the code in src/design/Button/index.tsx that checks whether the child is a Link (`isLinkComponent`). Depending on what we decide, we should delete it completely (or fix it).

In production, this check isn't successful in the instance page for the "Open Workflow" button. I could not debug it completely because the zod error messages are very hard to read.

Playwright tests ran successfully locally so I don't think my changes broke anything (but a few of the tests seem to be a bit flaky).

We should discuss whether we should: (a) use the Button with my fix in the future. This means we have to specify "isAnchor" manually and it isn't computed. (b) fix whatever the underlying cause was for the different behavior in development and production.

I may be missing something obvios, but I would vote (a).

My reasoning for that:

We have 2 instances of the button where it is used with "asChild" and a Link is passed in. The method for calculating "isAnchor" is called very often when it doesn't matter, and it is very hard to debug because zod errors aren't logged in production and if they were, they are always very hard to read so debugging remains difficult. So given the fact that there are only 2 use cases I say this code added complexity isn't worth it and adding "isAnchor" manually in rare cases is totally acceptable.

The changes in `src/util/router/pages.tsx` aren't strictly necessary. I just noticed there was always a `?` at the end of an url even without any urlSearchParams. So I added logic to prevent the ? and made the code a bit easier to follow.

But the extra ? didn't actually cause any problems (as I first suspected).
