### PR TITLE
[DIR-887] no logs for pods

### DIFF
--- a/src/api/services/index.ts
+++ b/src/api/services/index.ts
@@ -81,7 +81,7 @@ export const serviceKeys = {
   }: {
     apiKey?: string;
     name: string;
-    namespace?: string;
+    namespace: string;
   }) =>
     [
       {

--- a/src/api/services/query/revision/pods/getLogs.ts
+++ b/src/api/services/query/revision/pods/getLogs.ts
@@ -28,6 +28,7 @@ export const usePodLogsStream = (
     onMessage: (msg) => {
       queryClient.setQueryData<PodLogsSchemaType>(
         serviceKeys.podLogs({
+          namespace,
           name,
           apiKey: apiKey ?? undefined,
         }),


### PR DESCRIPTION
This fixes an issue where logs from pods did not show up in the UI. The problem was that the `useQuery` subscribed to a cache key with a namespace field in it and the streaming provider wrote the data in a cache that did not have the namespace in the cache key. 

This did not show up as a TS issue, since the namespace was not mandatory in the cache key. I guess this was either typed as optional by mistake, or it might come from an earlier implementation version.

I changed the following:
- namespace is now mandatory (there are now TS errors, so this should be fine)
- `usePodLogsStream` now writes to the cache key with the namespace in it

After this change, I get logs on both pages, the services and the workflow services