### PR TITLE
[DIR-855] [DIR-746] [DIR-888] - fix scroll virtualization issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@tailwindcss/nesting": "^0.0.0-insiders.565cd3e",
     "@tanstack/react-query": "^4.26.0",
     "@tanstack/react-query-devtools": "^4.28.0",
-    "@tanstack/react-virtual": "^3.0.0-beta.54",
+    "@tanstack/react-virtual": "^3.0.0-beta.60",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -37,5 +37,5 @@ export const FileSchema = z.custom<File>((value) => {
   }
 });
 
-export const LogLevelSchema = z.enum(["debug", "info", "error"]);
+export const LogLevelSchema = z.enum(["debug", "info", "error", "warn"]);
 export type LogLevelSchemaType = z.infer<typeof LogLevelSchema>;

--- a/src/api/streaming.ts
+++ b/src/api/streaming.ts
@@ -100,7 +100,10 @@ export const useStreaming = <T>({
 
       const parsedResult = schema.safeParse(msgJson);
       if (parsedResult.success === false) {
-        console.error(`error parsing streaming result for ${url}`);
+        console.error(
+          `error parsing streaming result for ${url}`,
+          parsedResult.error
+        );
         return;
       }
 

--- a/src/pages/namespace/Instances/Detail/Main/Logs/ScrollContainer.tsx
+++ b/src/pages/namespace/Instances/Detail/Main/Logs/ScrollContainer.tsx
@@ -43,37 +43,12 @@ const ScrollContainer = () => {
      * to have no flickering with pretty high scrolling speed.
      */
     overscan: 40,
-    getItemKey: (index) => logData?.results[index]?.t ?? index,
   });
 
   useEffect(() => {
     if (logData?.results.length && watch) {
-      /**
-       * monkey patch ahead 🙈
-       * calling rowVirtualizer.scrollToIndex(logData?.results.length);
-       * is supposed to scroll to the bottom of the list, but it doesn't
-       * work when the height of the line is dynamic. The calcuation that
-       * is used only takes the result of estimateSize call into account
-       * (we can test that by setting estimateSize very high)
-       *
-       * the only solution that workd for now is calling
-       * rowVirtualizer.scrollElement with a very high top value
-       * two times in a row, with a small delay for one a render
-       * cycle in between
-       */
-      rowVirtualizer.scrollElement?.scrollTo({
-        top: 999999999999999,
-      });
-
-      const timeOut = setTimeout(() => {
-        rowVirtualizer.scrollElement?.scrollTo({
-          top: 999999999999999,
-        });
-      }, 10);
-
-      return () => {
-        clearTimeout(timeOut);
-      };
+      rowVirtualizer.scrollToIndex(logData?.results.length - 1),
+        { align: "end" };
     }
   }, [logData?.results.length, rowVirtualizer, watch]);
 

--- a/src/pages/namespace/Mirror/Activities/Detail/Logs/ScrollContainer.tsx
+++ b/src/pages/namespace/Mirror/Activities/Detail/Logs/ScrollContainer.tsx
@@ -34,37 +34,12 @@ const ScrollContainer = ({ activityId }: { activityId: string }) => {
      * to have no flickering with pretty high scrolling speed.
      */
     overscan: 40,
-    getItemKey: (index) => logData?.results[index]?.t ?? index,
   });
 
   useEffect(() => {
     if (logData?.results.length && watch) {
-      /**
-       * monkey patch ahead 🙈
-       * calling rowVirtualizer.scrollToIndex(logData?.results.length);
-       * is supposed to scroll to the bottom of the list, but it doesn't
-       * work when the height of the line is dynamic. The calcuation that
-       * is used only takes the result of estimateSize call into account
-       * (we can test that by setting estimateSize very high)
-       *
-       * the only solution that workd for now is calling
-       * rowVirtualizer.scrollElement with a very high top value
-       * two times in a row, with a small delay for one a render
-       * cycle in between
-       */
-      rowVirtualizer.scrollElement?.scrollTo({
-        top: 999999999999999,
-      });
-
-      const timeOut = setTimeout(() => {
-        rowVirtualizer.scrollElement?.scrollTo({
-          top: 999999999999999,
-        });
-      }, 10);
-
-      return () => {
-        clearTimeout(timeOut);
-      };
+      rowVirtualizer.scrollToIndex(logData?.results.length - 1),
+        { align: "end" };
     }
   }, [logData?.results.length, rowVirtualizer, watch]);
 

--- a/src/pages/namespace/Monitoring/Logs/Scrollcontainer.tsx
+++ b/src/pages/namespace/Monitoring/Logs/Scrollcontainer.tsx
@@ -34,37 +34,12 @@ const ScrollContainer = () => {
      * to have no flickering with pretty high scrolling speed.
      */
     overscan: 40,
-    getItemKey: (index) => logData?.results[index]?.t ?? index,
   });
 
   useEffect(() => {
     if (logData?.results.length && watch) {
-      /**
-       * monkey patch ahead 🙈
-       * calling rowVirtualizer.scrollToIndex(logData?.results.length);
-       * is supposed to scroll to the bottom of the list, but it doesn't
-       * work when the height of the line is dynamic. The calcuation that
-       * is used only takes the result of estimateSize call into account
-       * (we can test that by setting estimateSize very high)
-       *
-       * the only solution that workd for now is calling
-       * rowVirtualizer.scrollElement with a very high top value
-       * two times in a row, with a small delay for one a render
-       * cycle in between
-       */
-      rowVirtualizer.scrollElement?.scrollTo({
-        top: 999999999999999,
-      });
-
-      const timeOut = setTimeout(() => {
-        rowVirtualizer.scrollElement?.scrollTo({
-          top: 999999999999999,
-        });
-      }, 10);
-
-      return () => {
-        clearTimeout(timeOut);
-      };
+      rowVirtualizer.scrollToIndex(logData?.results.length - 1),
+        { align: "end" };
     }
   }, [logData?.results.length, rowVirtualizer, watch]);
 

--- a/src/pages/namespace/Services/Detail/Revision/Pods/ScrollContainer.tsx
+++ b/src/pages/namespace/Services/Detail/Revision/Pods/ScrollContainer.tsx
@@ -31,37 +31,11 @@ const ScrollContainer = ({ logs }: { logs: string[] }) => {
      * to have no flickering with pretty high scrolling speed.
      */
     overscan: 40,
-    getItemKey: (index) => index,
   });
 
   useEffect(() => {
     if (logs.length && watch) {
-      /**
-       * monkey patch ahead 🙈
-       * calling rowVirtualizer.scrollToIndex(logData?.results.length);
-       * is supposed to scroll to the bottom of the list, but it doesn't
-       * work when the height of the line is dynamic. The calcuation that
-       * is used only takes the result of estimateSize call into account
-       * (we can test that by setting estimateSize very high)
-       *
-       * the only solution that workd for now is calling
-       * rowVirtualizer.scrollElement with a very high top value
-       * two times in a row, with a small delay for one a render
-       * cycle in between
-       */
-      rowVirtualizer.scrollElement?.scrollTo({
-        top: 999999999999999,
-      });
-
-      const timeOut = setTimeout(() => {
-        rowVirtualizer.scrollElement?.scrollTo({
-          top: 999999999999999,
-        });
-      }, 10);
-
-      return () => {
-        clearTimeout(timeOut);
-      };
+      rowVirtualizer.scrollToIndex(logs.length - 1), { align: "end" };
     }
   }, [logs.length, rowVirtualizer, watch]);
 

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -43,6 +43,7 @@ export const logLevelToLogEntryVariant = (
 ): LogEntryVariant => {
   switch (level) {
     case "error":
+    case "warn":
       return "error";
     case "info":
       return "info";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4033,17 +4033,17 @@
     "@tanstack/query-core" "4.26.0"
     use-sync-external-store "^1.2.0"
 
-"@tanstack/react-virtual@^3.0.0-beta.54":
-  version "3.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.54.tgz#755979455adf13f2584937204a3f38703e446037"
-  integrity sha512-D1mDMf4UPbrtHRZZriCly5bXTBMhylslm4dhcHqTtDJ6brQcgGmk8YD9JdWBGWfGSWPKoh2x1H3e7eh+hgPXtQ==
+"@tanstack/react-virtual@^3.0.0-beta.60":
+  version "3.0.0-beta.60"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.60.tgz#2b37c0d72997a54f7927f6b159a77311429fec1e"
+  integrity sha512-F0wL9+byp7lf/tH6U5LW0ZjBqs+hrMXJrj5xcIGcklI0pggvjzMNW9DdIBcyltPNr6hmHQ0wt8FDGe1n1ZAThA==
   dependencies:
-    "@tanstack/virtual-core" "3.0.0-beta.54"
+    "@tanstack/virtual-core" "3.0.0-beta.60"
 
-"@tanstack/virtual-core@3.0.0-beta.54":
-  version "3.0.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.54.tgz#12259d007911ad9fce1388385c54a9141f4ecdc4"
-  integrity sha512-jtkwqdP2rY2iCCDVAFuaNBH3fiEi29aTn2RhtIoky8DTTiCdc48plpHHreLwmv1PICJ4AJUUESaq3xa8fZH8+g==
+"@tanstack/virtual-core@3.0.0-beta.60":
+  version "3.0.0-beta.60"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.60.tgz#fcac07cb182d41929208899062de8c9510cf42ed"
+  integrity sha512-QlCdhsV1+JIf0c0U6ge6SQmpwsyAT0oQaOSZk50AtEeAyQl9tQrd6qCHAslxQpgphrfe945abvKG8uYvw3hIGA==
 
 "@testing-library/dom@^8.3.0":
   version "8.17.1"


### PR DESCRIPTION
This PR addresses a problem with our `@tanstack/react-virtual` implementation

- Occurs in firefox on linux
- the problem grows, with the length of each log line (the longer the line, the more unpredictable the log item height)
- this also fixes an issue where mirror logs could failed validation because of a "new" loglevel named "warn". Like e.g. `Detected a possible deprecated workflow variable definition with an invalid name at: conditional-states/README.md`