### PR TITLE
[DIR-895] - show "No activities found" when mirror activities are empty

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -487,7 +487,8 @@
       },
       "activities": {
         "list": {
-          "title": "Activities"
+          "title": "Activities",
+          "noResults": "No activities found"
         },
         "detail": {
           "header": {

--- a/src/pages/namespace/Mirror/Activities/index.tsx
+++ b/src/pages/namespace/Mirror/Activities/index.tsx
@@ -1,7 +1,9 @@
 import {
   NoPermissions,
+  NoResult,
   Table,
   TableBody,
+  TableCell,
   TableHead,
   TableHeaderCell,
   TableRow,
@@ -22,12 +24,13 @@ import { useTranslation } from "react-i18next";
 const pageSize = 10;
 
 const Activities = () => {
-  const { data, isAllowed, noPermissionMessage } = useMirrorInfo();
+  const { data, isAllowed, noPermissionMessage, isFetched } = useMirrorInfo();
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const apiKey = useApiKey();
 
   const activities = data?.activities.results;
+  const noResults = isFetched && data?.activities.results.length === 0;
 
   if (!isAllowed)
     return (
@@ -91,6 +94,15 @@ const Activities = () => {
                   </TableRow>
                 </TableHead>
                 <TableBody>
+                  {noResults && (
+                    <TableRow className="hover:bg-inherit dark:hover:bg-inherit">
+                      <TableCell colSpan={4}>
+                        <NoResult icon={GitCompare}>
+                          {t("pages.mirror.activities.list.noResults")}
+                        </NoResult>
+                      </TableCell>
+                    </TableRow>
+                  )}
                   {currentItems.map((activity) => (
                     <Row
                       namespace={data.namespace}


### PR DESCRIPTION
This PR was ment to fix an issue where mirror logs were empty. This issue turned out to be invalid, but I found and fixed this on the way:

Show "No activities found" when mirror activities are empty. 
![CleanShot 2023-09-26 at 10 26 46](https://github.com/direktiv/direktiv-ui/assets/121789579/0c81b9b9-b8a4-41c2-8600-acc7efb5a309)
