### PR TITLE
[DIR-897] - "Go to homepage" link does not work on the 404 page

### DIFF
--- a/e2e/errorPage.spec.ts
+++ b/e2e/errorPage.spec.ts
@@ -1,0 +1,71 @@
+import { createNamespace, deleteNamespace } from "./utils/namespace";
+import { expect, test } from "@playwright/test";
+
+let namespace = "";
+
+test.beforeAll(async () => {
+  namespace = await createNamespace();
+});
+
+test.afterAll(async () => {
+  await deleteNamespace(namespace);
+  namespace = "";
+});
+
+test("the 404 error page shows, when the user opens a url that does not exist", async ({
+  page,
+}) => {
+  await page.goto("/this/page/does/not/exist");
+  await expect(page.getByTestId("error-title")).toHaveText("404");
+  await expect(page.getByTestId("error-message")).toHaveText("Not Found");
+});
+
+test("the back button on the 404 error page navigates the user back to the previous page", async ({
+  page,
+}) => {
+  await page.goto("/", { waitUntil: "networkidle" });
+  const defaultNamespaceUrl = await page.url();
+
+  expect(
+    defaultNamespaceUrl.endsWith("/explorer/tree"),
+    "the user was redirected to the file explorer of some default namespace"
+  ).toBe(true);
+
+  await page.goto("/this/page/does/not/exist");
+  expect(
+    await page.url(),
+    "the user navigated to some different non existing url"
+  ).not.toBe(defaultNamespaceUrl);
+
+  await page.getByTestId("error-back-btn").click();
+
+  expect(
+    await page.url(),
+    "clicking the back button on the 404 page navigates the user back to where they came from"
+  ).toBe(defaultNamespaceUrl);
+});
+
+test("the reload button on the error page reloads the current page", async ({
+  page,
+}) => {
+  await page.goto("/this/page/does/not/exist", { waitUntil: "networkidle" });
+  await page.getByTestId("error-reload-btn").click();
+
+  /**
+   * to test if the page will be reloaded, we wait for the request
+   * to the version endpoint that should be made on every page load
+   */
+  await page.waitForRequest("**/version");
+});
+
+test("the home button on the error page navigates the user to the home page", async ({
+  page,
+}) => {
+  await page.goto("/this/page/does/not/exist");
+  await page.getByTestId("error-home-btn").click();
+  const currentUrl = new URL(await page.url());
+  expect(
+    currentUrl.pathname,
+    "clicking the home button on the 404 page navigates the user back to where they came from"
+  ).toBe("/");
+});

--- a/src/util/router/ErrorPage.tsx
+++ b/src/util/router/ErrorPage.tsx
@@ -44,6 +44,7 @@ const ErrorPage = () => {
         <Button
           variant="primary"
           asChild
+          isAnchor
           className="col-span-2"
           data-testid="error-home-btn"
         >

--- a/src/util/router/ErrorPage.tsx
+++ b/src/util/router/ErrorPage.tsx
@@ -20,18 +20,33 @@ const ErrorPage = () => {
   return (
     <main className="flex h-screen w-full flex-col items-center justify-center gap-3">
       <Logo />
-      <div className="text-4xl font-bold">{errorTitle}</div>
-      <div>{errorMessage}</div>
+      <div className="text-4xl font-bold" data-testid="error-title">
+        {errorTitle}
+      </div>
+      <div data-testid="error-message">{errorMessage}</div>
       <div className="grid grid-cols-2 gap-3">
-        <Button variant="outline" onClick={() => window.history.back()}>
+        <Button
+          variant="outline"
+          onClick={() => window.history.back()}
+          data-testid="error-back-btn"
+        >
           <ArrowLeft />
           {t("pages.error.goBack")}
         </Button>
-        <Button variant="outline" onClick={() => location.reload()}>
+        <Button
+          variant="outline"
+          onClick={() => location.reload()}
+          data-testid="error-reload-btn"
+        >
           <RefreshCcw />
           {t("pages.error.reload")}
         </Button>
-        <Button variant="primary" asChild className="col-span-2">
+        <Button
+          variant="primary"
+          asChild
+          className="col-span-2"
+          data-testid="error-home-btn"
+        >
           <Link to="/">
             <Home />
             {t("pages.error.goHome")}


### PR DESCRIPTION
This PR fixes an issue on the error page, whre the "Go to homepage" link is not working. After we introduced the `isAnchor` property to links that look like buttons, we did not add the prop to this button.

I also added e2e tests for the error page in general to cover this bug and basic functionality of the error page.