### PR TITLE
[DIR-911] update versions schema

### DIFF
--- a/src/api/version/schema.ts
+++ b/src/api/version/schema.ts
@@ -1,7 +1,14 @@
 import { z } from "zod";
 
+/**
+ * example:
+ * 
+  {
+    "api": "4d1cc3a",
+    "flow": "4d1cc3a",
+    "functions": "4d1cc3a"
+  }
+ */
 export const VersionSchema = z.object({
   api: z.string(),
-  flow: z.string(),
-  functions: z.string(),
 });


### PR DESCRIPTION
Updates the version schema to only use the fields that we actually need. This will prevent the UI to throw an error when, flow or functions are not set.