### PR TITLE
[DIR-914] no directory hint when deleting a file

### DIFF
--- a/e2e/explorer/index.spec.ts
+++ b/e2e/explorer/index.spec.ts
@@ -358,6 +358,15 @@ test(`it is possible to delete a worfklow`, async ({ page }) => {
     .getByTestId("dropdown-trg-node-actions")
     .click();
   await page.getByTestId("node-actions-delete").click();
+
+  await expect(
+    page.getByText(
+      `Are you sure you want to delete ${name}? This cannot be undone.`,
+      {
+        exact: true,
+      }
+    )
+  ).toBeVisible();
   await page.getByTestId("node-delete-confirm").click();
 
   await expect(
@@ -571,6 +580,16 @@ test(`it is possible to delete a directory`, async ({ page }) => {
     .getByTestId("dropdown-trg-node-actions")
     .click();
   await page.getByTestId("node-actions-delete").click();
+
+  await expect(
+    page.getByText(
+      `Are you sure you want to delete ${name}? This cannot be undone. All content of this directory will be deleted as well.`,
+      {
+        exact: true,
+      }
+    )
+  ).toBeVisible();
+
   await page.getByTestId("node-delete-confirm").click();
 
   await expect(

--- a/src/pages/namespace/Explorer/Tree/Delete.tsx
+++ b/src/pages/namespace/Explorer/Tree/Delete.tsx
@@ -37,8 +37,9 @@ const Delete = ({
         <Trans
           i18nKey="pages.explorer.tree.delete.commonMsg"
           values={{ name: node.name }}
-        />{" "}
-        {t("pages.explorer.tree.delete.directoryMsg")}
+        />
+        {node.type === "directory" &&
+          ` ${t("pages.explorer.tree.delete.directoryMsg")}`}
       </div>
       <DialogFooter>
         <DialogClose asChild>


### PR DESCRIPTION
Deleting a YAML file shows: "All content of this directory will be deleted as well." This hint should only be visible when deleting a directory.