### PR TITLE
[DIR-933] endpoint file type

### DIFF
--- a/src/api/tree/schema/node.ts
+++ b/src/api/tree/schema/node.ts
@@ -7,7 +7,7 @@ const NodeSchema = z.object({
   name: z.string(),
   path: z.string(),
   parent: z.string(),
-  type: z.enum(["directory", "workflow", "file"]),
+  type: z.enum(["directory", "workflow", "file", "endpoint"]),
   attributes: z.array(z.string()), // must be more specified
   oid: z.string(),
   readOnly: z.boolean(),


### PR DESCRIPTION
The gateway config will improve a new file type called "endpoint". This is already implemented in branch `main` of the api repository.

To create a new "endpoint" file, you have to create a namespace called "gateway_namespace". This namespace will have additional features.

Then, create a workflow.yaml file with this content (I think only the first line is really relevant for now):
```
direktiv_api: "endpoint/v1"
method: "POST"
plugins:
- type: "router_weighted"
  config:
    backends:
    - namespace: "my_namespace"
      workflow: "/path/to/workflow.yaml"
      weight: 90
    - namespace: "my_namespace"
      workflow: "/path/to/workflow2.yaml"
      weight: 10
```

The API will then create an "endpoint" file, but currently the ui will throw an error when parsing the resonse, because the file type isn't in the zod enum.

This PR updates the schema to avoid that error. It would be useful to merge it ahead of our own feature implementation to avoid running into errors when using the newest API.
