### PR TITLE
[DIR-967] add consumer to file types

### DIFF
--- a/src/api/tree/schema/node.ts
+++ b/src/api/tree/schema/node.ts
@@ -7,7 +7,14 @@ const NodeSchema = z.object({
   name: z.string(),
   path: z.string(),
   parent: z.string(),
-  type: z.enum(["directory", "workflow", "file", "service", "endpoint"]),
+  type: z.enum([
+    "directory",
+    "workflow",
+    "file",
+    "service",
+    "endpoint",
+    "consumer",
+  ]),
   attributes: z.array(z.string()), // must be more specified
   oid: z.string(),
   readOnly: z.boolean(),

--- a/src/api/tree/utils.ts
+++ b/src/api/tree/utils.ts
@@ -1,4 +1,4 @@
-import { File, Folder, Layers, Play } from "lucide-react";
+import { File, Folder, Layers, Network, Play, Users } from "lucide-react";
 
 import { NodeSchemaType } from "./schema/node";
 
@@ -52,6 +52,10 @@ export const fileTypeToIcon = (type: NodeSchemaType["type"]) => {
       return Layers;
     case "workflow":
       return Play;
+    case "endpoint":
+      return Network;
+    case "consumer":
+      return Users;
     default:
       return File;
   }

--- a/src/api/tree/utils.ts
+++ b/src/api/tree/utils.ts
@@ -67,3 +67,6 @@ export const fileTypeToExplorerSubpage = (type: NodeSchemaType["type"]) => {
       return undefined;
   }
 };
+
+export const isPreviewable = (type: NodeSchemaType["type"]) =>
+  type === "file" || type === "consumer" || type === "endpoint";

--- a/src/design/Editor/utils.ts
+++ b/src/design/Editor/utils.ts
@@ -36,6 +36,8 @@ export const editorLanguageSchema = z
       case "application/x-csh":
         return "shell";
       case "text/yaml":
+      case "application/direktiv":
+        return "yaml";
       default:
         if (val.startsWith("text/")) {
           return "plaintext";

--- a/src/pages/namespace/Explorer/Tree/FileRow/ConditionalLink.tsx
+++ b/src/pages/namespace/Explorer/Tree/FileRow/ConditionalLink.tsx
@@ -1,9 +1,9 @@
 import { FC, PropsWithChildren } from "react";
+import { fileTypeToExplorerSubpage, isPreviewable } from "~/api/tree/utils";
 
 import { DialogTrigger } from "~/design/Dialog";
 import { Link } from "react-router-dom";
 import { NodeSchemaType } from "~/api/tree/schema/node";
-import { fileTypeToExplorerSubpage } from "~/api/tree/utils";
 import { pages } from "~/util/router/pages";
 
 type ConditionalLinkProps = PropsWithChildren & {
@@ -18,9 +18,8 @@ export const ConditionalLink: FC<ConditionalLinkProps> = ({
   onPreviewClicked,
   children,
 }) => {
-  const isFile = node.type === "file";
-
-  if (isFile)
+  const linkToPreview = isPreviewable(node.type);
+  if (linkToPreview)
     return (
       <DialogTrigger
         className="flex-1 hover:underline"


### PR DESCRIPTION
This PR adds the type consumer to the file type schema to prepare for the gateway release.  It also introduces an icon for "endpoint" and "consumer" files and makes them previewable