### PR TITLE
[DIR-1036] clean up ci

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,6 +1,6 @@
 name: Create and push PR Docker image
 
-on: pull_request
+on: workflow_dispatch
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,5 +1,5 @@
 name: Playwright Tests
-on: pull_request
+on: workflow_dispatch
 jobs:
   test:
     timeout-minutes: 45

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,11 +6,11 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3
-      
+
       - uses: actions/setup-node@v3
         with:
           node-version: 18.18.1
-      
+
       # Cache Node Modules
       - name: Cache Node Modules
         uses: actions/cache@v2
@@ -19,7 +19,7 @@ jobs:
           key: node-modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             node-modules-${{ runner.os }}-
-      
+
       - name: Install yarn
         run: npm install -g yarn
       - name: Install project dependencies
@@ -37,7 +37,7 @@ jobs:
         run: yarn playwright install-deps --dry-run
       - name: Install Playwright Browsers
         run: yarn playwright install
-      
+
       - name: Run Playwright tests
         run: yarn playwright test
         env:
@@ -45,7 +45,7 @@ jobs:
           VITE_E2E_UI_PORT: ${{ vars.VITE_E2E_UI_PORT }}
           VITE_DEV_API_DOMAIN: ${{ vars.VITE_DEV_API_DOMAIN }}
           VITE_E2E_API_TOKEN: ${{ vars.VITE_E2E_API_TOKEN }}
-      
+
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,7 +1,7 @@
 name: "Publish Storybook to Chromatic"
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: ["main"]
 jobs:
   build:
     name: Build and test design system

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -2,7 +2,7 @@ name: Make test build
 on:
   push:
     branches-ignore:
-      - 'main'
+      - "main"
 jobs:
   build:
     name: Make build and run testsuite


### PR DESCRIPTION
This cleans up our current CI pipeline:
- disabled playwright: Playwright test in CI were not valid anymore because the API in CI was never up-to-date. We are switching to manual testing before every PR merge. A possible solution could be spinning up the api with the docker driver which might be lightweight enough to run in an action
- disable docker build (preview server has been wiped)