### PR TITLE
Fix filtering by after/before with exact time

### DIFF
--- a/src/pages/namespace/Events/History/components/Filters/RefineTime.tsx
+++ b/src/pages/namespace/Events/History/components/Filters/RefineTime.tsx
@@ -31,7 +31,7 @@ const RefineTime = ({
 
     date.setHours(hr, min, sec);
     setFilter({
-      [field]: { type: "MATCH", value: date },
+      [field]: { type: field, value: date },
     });
   };
 

--- a/src/pages/namespace/Instances/components/Filters/RefineTime.tsx
+++ b/src/pages/namespace/Instances/components/Filters/RefineTime.tsx
@@ -31,7 +31,7 @@ const RefineTime = ({
 
     date.setHours(hr, min, sec);
     setFilter({
-      [field]: { type: "MATCH", value: date },
+      [field]: { type: field, value: date },
     });
   };
 


### PR DESCRIPTION
The query string created by the UI was wrong (filter.type "MATCH" instead of "AFTER" or "BEFORE" after picking a t@ime).

@stefan-kracht setting `[field]` dynamically in this line of code means TypeScript will not ensure that the following values are valid.  Do you have any ideas on how to improve this?

```
    setFilter({
      [field]: { type: field, value: date },
    });
 ```