### PR TITLE
[DIR-912] Switching between views in workflow view wipes content

### DIFF
--- a/e2e/explorer/workflow/diagramEditor.spec.ts
+++ b/e2e/explorer/workflow/diagramEditor.spec.ts
@@ -301,3 +301,33 @@ test("it is possible to use the diagram view on the revisions detail page as wel
   await expect(editor).toBeVisible();
   await expect(diagram).toBeVisible();
 });
+
+test("it is possible to switch from Code View to Diagram View without loosing the recent changes", async ({
+  page,
+}) => {
+  await page.goto(`/${namespace}/explorer/workflow/active/${workflow}`);
+
+  const { codeBtn, diagramBtn } = await getCommonPageElements(page);
+
+  const firstLine = page.getByText("direktiv_api: workflow/v1");
+  await firstLine.click();
+
+  const workflowChanges = "some changes to the workflows code";
+  await page.type("textarea", workflowChanges);
+  const recentlyChanges = page.getByText(workflowChanges);
+  await expect(
+    recentlyChanges,
+    "after the user typed new workflow code, it will be visible in the editor"
+  ).toBeVisible();
+
+  await diagramBtn.click();
+  await expect(
+    recentlyChanges,
+    "when the user switches to the Diagram View, the most recent code changes are not visible anymore"
+  ).not.toBeVisible();
+  await codeBtn.click();
+  await expect(
+    recentlyChanges,
+    "after the user switched back to the Editor View, the most recent chages are still in the Editor"
+  ).toBeVisible();
+});

--- a/src/pages/namespace/Explorer/Workflow/Active/WorkflowEditor.tsx
+++ b/src/pages/namespace/Explorer/Workflow/Active/WorkflowEditor.tsx
@@ -5,7 +5,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "~/design/Dropdown";
-import { FC, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { GitBranchPlus, Play, Save, Tag, Undo } from "lucide-react";
 
 import Button from "~/design/Button";
@@ -56,6 +56,15 @@ const WorkflowEditor: FC<{
   });
 
   const [editorContent, setEditorContent] = useState(workflowDataFromServer);
+
+  /**
+   * When the server state of the content changes, the internal state needs to be updated,
+   * to have the editor and diagram up to date. This is important, when the user is reverting
+   * to an old revision.
+   */
+  useEffect(() => {
+    setEditorContent(workflowDataFromServer);
+  }, [workflowDataFromServer]);
 
   const { mutate: createRevision } = useCreateRevision();
   const { mutate: revertRevision } = useRevertRevision({

--- a/src/pages/namespace/Explorer/Workflow/Active/WorkflowEditor.tsx
+++ b/src/pages/namespace/Explorer/Workflow/Active/WorkflowEditor.tsx
@@ -90,14 +90,11 @@ const WorkflowEditor: FC<{
       <WorkspaceLayout
         layout={currentLayout}
         diagramComponent={
-          <Diagram
-            workflowData={workflowDataFromServer}
-            layout={currentLayout}
-          />
+          <Diagram workflowData={editorContent} layout={currentLayout} />
         }
         editorComponent={
           <CodeEditor
-            value={workflowDataFromServer}
+            value={editorContent}
             onValueChange={onEditorContentUpdate}
             createdAt={data.revision?.createdAt}
             error={error}


### PR DESCRIPTION
This PR fixes a bug in the workflow editor where the most recent changes got lost when the user switched to the diagram view and then back to the code editor view.

The bugfix itself was actually very simple, but I had to introduce a `useEffect` as well to handle a side effect that occurs when the user clicks the "revert to previous revision" (luckily, this was covered by a test and was probably the root cause of why the internal state was designed this way). 

I also introduced an e2e to cover the correct behavior.

All e2e test are passing with the api at commit `46e73a0de70f9e0bb75319300933916a08a52517`