### PR TITLE
[DIR-1046] add ee gateway plugins

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -382,7 +382,8 @@
                 "types": {
                   "acl": "Access control list (acl)",
                   "js-inbound": "JavaScript",
-                  "request-convert": "Request convert"
+                  "request-convert": "Request convert",
+                  "event-filter": "Event Filter"
                 },
                 "jsInbound": {
                   "script": "JavaScript"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -365,6 +365,9 @@
                   "variable": "Variable",
                   "contentType": "Content Type (optional)",
                   "contentTypePlaceholder": "application/json"
+                },
+                "targetEvent": {
+                  "namespace": "Namespace (optional)"
                 }
               },
               "inbound": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -386,7 +386,7 @@
                   "acl": "Access control list (acl)",
                   "js-inbound": "JavaScript",
                   "request-convert": "Request convert",
-                  "event-filter": "Event Filter"
+                  "event-filter": "Event filter"
                 },
                 "jsInbound": {
                   "script": "JavaScript"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -330,7 +330,8 @@
                   "target-flow": "Workflow",
                   "target-flow-var": "Workflow Variable",
                   "target-namespace-file": "Namespace File",
-                  "target-namespace-var": "Namespace Variable"
+                  "target-namespace-var": "Namespace Variable",
+                  "target-event": "Event"
                 },
                 "instantResponse": {
                   "statusCode": "Status Code",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -404,6 +404,10 @@
                   "deny_tags": "Deny tags (optional)",
                   "groupPlaceholder": "Enter a group",
                   "tagPlaceholder": "Enter a tag"
+                },
+                "eventFilter": {
+                  "script": "JavaScript",
+                  "allow_non_events": "Allow non events (optional)"
                 }
               },
               "outbound": {

--- a/src/api/enterprise/session/schema.ts
+++ b/src/api/enterprise/session/schema.ts
@@ -1,3 +1,5 @@
 import { z } from "zod";
 
-export const SessionSchema = z.string();
+export const SessionSchema = z.object({
+  response: z.string(),
+});

--- a/src/api/gateway/schema.ts
+++ b/src/api/gateway/schema.ts
@@ -26,7 +26,7 @@ export const MethodsSchema = z.enum(routeMethods);
  */
 const PluginSchema = z.object({
   type: z.string(),
-  configuration: z.record(z.unknown()).nullable(),
+  configuration: z.record(z.unknown()).optional(),
 });
 
 /**

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Auth/BasicAuthForm.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Auth/BasicAuthForm.tsx
@@ -14,7 +14,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 type OptionalConfig = Partial<BasicAuthFormSchemaType["configuration"]>;
 
-const predfinedConfig: OptionalConfig = {
+const predefinedConfig: OptionalConfig = {
   add_groups_header: false,
   add_tags_header: false,
   add_username_header: false,
@@ -42,7 +42,7 @@ export const BasicAuthForm: FC<FormProps> = ({
     defaultValues: {
       type: "basic-auth",
       configuration: {
-        ...predfinedConfig,
+        ...predefinedConfig,
         ...defaultConfig,
       },
     },

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Auth/KeyAuthForm.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Auth/KeyAuthForm.tsx
@@ -16,7 +16,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 type OptionalConfig = Partial<KeyAuthFormSchemaType["configuration"]>;
 
-const predfinedConfig: OptionalConfig = {
+const predefinedConfig: OptionalConfig = {
   add_groups_header: true,
   add_tags_header: true,
   add_username_header: true,
@@ -45,7 +45,7 @@ export const KeyAuthForm: FC<FormProps> = ({
     defaultValues: {
       type: "key-auth",
       configuration: {
-        ...predfinedConfig,
+        ...predefinedConfig,
         ...defaultConfig,
       },
     },

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Auth/index.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Auth/index.tsx
@@ -163,17 +163,17 @@ export const AuthPluginForm: FC<AuthPluginFormProps> = ({ formControls }) => {
               />
             </SelectTrigger>
             <SelectContent>
-              {availablePlugins.map((pluginType) => (
-                <SelectItem key={pluginType} value={pluginType}>
+              {availablePlugins.map(({ name: pluginName }) => (
+                <SelectItem key={pluginName} value={pluginName}>
                   {t(
-                    `pages.explorer.endpoint.editor.form.plugins.auth.types.${pluginType}`
+                    `pages.explorer.endpoint.editor.form.plugins.auth.types.${pluginName}`
                   )}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
         </PluginSelector>
-        {selectedPlugin === authPluginTypes.basicAuth && (
+        {selectedPlugin === authPluginTypes.basicAuth.name && (
           <BasicAuthForm
             formId={formId}
             defaultConfig={getBasicAuthConfigAtIndex(fields, editIndex)}
@@ -188,7 +188,7 @@ export const AuthPluginForm: FC<AuthPluginFormProps> = ({ formControls }) => {
             }}
           />
         )}
-        {selectedPlugin === authPluginTypes.keyAuth && (
+        {selectedPlugin === authPluginTypes.keyAuth.name && (
           <KeyAuthForm
             formId={formId}
             defaultConfig={getKeyAuthConfigAtIndex(fields, editIndex)}
@@ -203,7 +203,7 @@ export const AuthPluginForm: FC<AuthPluginFormProps> = ({ formControls }) => {
             }}
           />
         )}
-        {selectedPlugin === authPluginTypes.githubWebhookAuth && (
+        {selectedPlugin === authPluginTypes.githubWebhookAuth.name && (
           <GithubWebhookAuthForm
             formId={formId}
             defaultConfig={getGithubWebhookAuthConfigAtIndex(fields, editIndex)}

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Auth/index.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Auth/index.tsx
@@ -12,6 +12,10 @@ import {
 import { Table, TableBody, TableCell, TableRow } from "~/design/Table";
 import { UseFormReturn, useFieldArray } from "react-hook-form";
 import {
+  authPluginTypes,
+  availablePlugins,
+} from "../../../schema/plugins/auth";
+import {
   getBasicAuthConfigAtIndex,
   getGithubWebhookAuthConfigAtIndex,
   getKeyAuthConfigAtIndex,
@@ -25,7 +29,6 @@ import { EndpointFormSchemaType } from "../../../schema";
 import { GithubWebhookAuthForm } from "./GithubWebhookAuthForm";
 import { KeyAuthForm } from "./KeyAuthForm";
 import { Plus } from "lucide-react";
-import { authPluginTypes } from "../../../schema/plugins/auth";
 import { useTranslation } from "react-i18next";
 
 type AuthPluginFormProps = {
@@ -160,7 +163,7 @@ export const AuthPluginForm: FC<AuthPluginFormProps> = ({ formControls }) => {
               />
             </SelectTrigger>
             <SelectContent>
-              {Object.values(authPluginTypes).map((pluginType) => (
+              {availablePlugins.map((pluginType) => (
                 <SelectItem key={pluginType} value={pluginType}>
                   {t(
                     `pages.explorer.endpoint.editor.form.plugins.auth.types.${pluginType}`

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/AclForm.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/AclForm.tsx
@@ -14,7 +14,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 type OptionalConfig = Partial<AclFormSchemaType["configuration"]>;
 
-const predfinedConfig: OptionalConfig = {
+const predefinedConfig: OptionalConfig = {
   allow_groups: [],
   deny_groups: [],
   allow_tags: [],
@@ -38,7 +38,7 @@ export const AclForm: FC<FormProps> = ({ defaultConfig, onSubmit, formId }) => {
     defaultValues: {
       type: "acl",
       configuration: {
-        ...predfinedConfig,
+        ...predefinedConfig,
         ...defaultConfig,
       },
     },

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/EventFilterForm.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/EventFilterForm.tsx
@@ -17,7 +17,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 type OptionalConfig = Partial<EventFilterFormSchemaType["configuration"]>;
 
-const predfinedConfig: OptionalConfig = {
+const predefinedConfig: OptionalConfig = {
   allow_non_events: false,
 };
 
@@ -44,7 +44,7 @@ export const EventFilterForm: FC<FormProps> = ({
     defaultValues: {
       type: "event-filter",
       configuration: {
-        ...predfinedConfig,
+        ...predefinedConfig,
         ...defaultConfig,
       },
     },

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/EventFilterForm.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/EventFilterForm.tsx
@@ -1,0 +1,109 @@
+import { Controller, useForm } from "react-hook-form";
+import {
+  EventFilterFormSchema,
+  EventFilterFormSchemaType,
+} from "../../../schema/plugins/inbound/eventFilter";
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/componentsNext/FormErrors";
+
+import { Card } from "~/design/Card";
+import { Checkbox } from "~/design/Checkbox";
+import Editor from "~/design/Editor";
+import { Fieldset } from "~/pages/namespace/Explorer/components/Fieldset";
+import { PluginWrapper } from "../components/Modal";
+import { useTheme } from "~/util/store/theme";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<EventFilterFormSchemaType["configuration"]>;
+
+const predfinedConfig: OptionalConfig = {
+  allow_non_events: false,
+};
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: EventFilterFormSchemaType) => void;
+};
+
+export const EventFilterForm: FC<FormProps> = ({
+  defaultConfig,
+  onSubmit,
+  formId,
+}) => {
+  const { t } = useTranslation();
+  const {
+    handleSubmit,
+    setValue,
+    getValues,
+    formState: { errors },
+    control,
+  } = useForm<EventFilterFormSchemaType>({
+    resolver: zodResolver(EventFilterFormSchema),
+    defaultValues: {
+      type: "event-filter",
+      configuration: {
+        ...predfinedConfig,
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  const theme = useTheme();
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      {errors?.configuration && (
+        <FormErrors
+          errors={errors?.configuration as errorsType}
+          className="mb-5"
+        />
+      )}
+      <PluginWrapper>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.eventFilter.script"
+          )}
+        >
+          <Card className="h-[200px] w-full p-5" background="weight-1" noShadow>
+            <Controller
+              control={control}
+              name="configuration.script"
+              render={({ field }) => (
+                <Editor
+                  theme={theme ?? undefined}
+                  language="javascript"
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          </Card>
+        </Fieldset>
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.inbound.eventFilter.allow_non_events"
+          )}
+          htmlFor="allow_non_events"
+          horizontal
+        >
+          <Checkbox
+            defaultChecked={getValues("configuration.allow_non_events")}
+            onCheckedChange={(value) => {
+              if (typeof value === "boolean") {
+                setValue("configuration.allow_non_events", value);
+              }
+            }}
+            id="allow_non_events"
+          />
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/RequestConvertForm.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/RequestConvertForm.tsx
@@ -14,7 +14,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 type OptionalConfig = Partial<RequestConvertFormSchemaType["configuration"]>;
 
-const predfinedConfig: OptionalConfig = {
+const predefinedConfig: OptionalConfig = {
   omit_body: false,
   omit_headers: false,
   omit_consumer: false,
@@ -43,7 +43,7 @@ export const RequestConvertForm: FC<FormProps> = ({
     defaultValues: {
       type: "request-convert",
       configuration: {
-        ...predfinedConfig,
+        ...predefinedConfig,
         ...defaultConfig,
       },
     },

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/index.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/index.tsx
@@ -167,17 +167,17 @@ export const InboundPluginForm: FC<InboundPluginFormProps> = ({ form }) => {
               />
             </SelectTrigger>
             <SelectContent>
-              {availablePlugins.map((pluginType) => (
-                <SelectItem key={pluginType} value={pluginType}>
+              {availablePlugins.map(({ name: pluginName }) => (
+                <SelectItem key={pluginName} value={pluginName}>
                   {t(
-                    `pages.explorer.endpoint.editor.form.plugins.inbound.types.${pluginType}`
+                    `pages.explorer.endpoint.editor.form.plugins.inbound.types.${pluginName}`
                   )}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
         </PluginSelector>
-        {selectedPlugin === requestConvert && (
+        {selectedPlugin === requestConvert.name && (
           <RequestConvertForm
             formId={formId}
             defaultConfig={getRequestConvertConfigAtIndex(fields, editIndex)}
@@ -192,7 +192,7 @@ export const InboundPluginForm: FC<InboundPluginFormProps> = ({ form }) => {
             }}
           />
         )}
-        {selectedPlugin === jsInbound && (
+        {selectedPlugin === jsInbound.name && (
           <JsInboundForm
             formId={formId}
             defaultConfig={getJsInboundConfigAtIndex(fields, editIndex)}
@@ -207,7 +207,7 @@ export const InboundPluginForm: FC<InboundPluginFormProps> = ({ form }) => {
             }}
           />
         )}
-        {selectedPlugin === acl && (
+        {selectedPlugin === acl.name && (
           <AclForm
             formId={formId}
             defaultConfig={getAclConfigAtIndex(fields, editIndex)}
@@ -222,7 +222,7 @@ export const InboundPluginForm: FC<InboundPluginFormProps> = ({ form }) => {
             }}
           />
         )}
-        {selectedPlugin === eventFilter && (
+        {selectedPlugin === eventFilter.name && (
           <EventFilterForm
             formId={formId}
             defaultConfig={getEventFilterConfigAtIndex(fields, editIndex)}

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/index.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/index.tsx
@@ -12,6 +12,10 @@ import {
 import { Table, TableBody, TableCell, TableRow } from "~/design/Table";
 import { UseFormReturn, useFieldArray } from "react-hook-form";
 import {
+  availablePlugins,
+  inboundPluginTypes,
+} from "../../../schema/plugins/inbound";
+import {
   getAclConfigAtIndex,
   getEventFilterConfigAtIndex,
   getJsInboundConfigAtIndex,
@@ -27,7 +31,6 @@ import { InboundPluginFormSchemaType } from "../../../schema/plugins/inbound/sch
 import { JsInboundForm } from "./JsInboundForm";
 import { Plus } from "lucide-react";
 import { RequestConvertForm } from "./RequestConvertForm";
-import { inboundPluginTypes } from "../../../schema/plugins/inbound";
 import { useTranslation } from "react-i18next";
 
 type InboundPluginFormProps = {
@@ -164,7 +167,7 @@ export const InboundPluginForm: FC<InboundPluginFormProps> = ({ form }) => {
               />
             </SelectTrigger>
             <SelectContent>
-              {Object.values(inboundPluginTypes).map((pluginType) => (
+              {availablePlugins.map((pluginType) => (
                 <SelectItem key={pluginType} value={pluginType}>
                   {t(
                     `pages.explorer.endpoint.editor.form.plugins.inbound.types.${pluginType}`

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/index.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Inbound/index.tsx
@@ -13,6 +13,7 @@ import { Table, TableBody, TableCell, TableRow } from "~/design/Table";
 import { UseFormReturn, useFieldArray } from "react-hook-form";
 import {
   getAclConfigAtIndex,
+  getEventFilterConfigAtIndex,
   getJsInboundConfigAtIndex,
   getRequestConvertConfigAtIndex,
 } from "../utils";
@@ -21,6 +22,7 @@ import { AclForm } from "./AclForm";
 import Button from "~/design/Button";
 import { Card } from "~/design/Card";
 import { EndpointFormSchemaType } from "../../../schema";
+import { EventFilterForm } from "./EventFilterForm";
 import { InboundPluginFormSchemaType } from "../../../schema/plugins/inbound/schema";
 import { JsInboundForm } from "./JsInboundForm";
 import { Plus } from "lucide-react";
@@ -51,7 +53,7 @@ export const InboundPluginForm: FC<InboundPluginFormProps> = ({ form }) => {
   const [selectedPlugin, setSelectedPlugin] =
     useState<InboundPluginFormSchemaType["type"]>();
 
-  const { jsInbound, requestConvert, acl } = inboundPluginTypes;
+  const { jsInbound, requestConvert, acl, eventFilter } = inboundPluginTypes;
 
   const pluginsCount = fields.length;
   const formId = "inboundPluginForm";
@@ -202,11 +204,25 @@ export const InboundPluginForm: FC<InboundPluginFormProps> = ({ form }) => {
             }}
           />
         )}
-
         {selectedPlugin === acl && (
           <AclForm
             formId={formId}
             defaultConfig={getAclConfigAtIndex(fields, editIndex)}
+            onSubmit={(configuration) => {
+              setDialogOpen(false);
+              if (editIndex === undefined) {
+                addPlugin(configuration);
+              } else {
+                editPlugin(editIndex, configuration);
+              }
+              setEditIndex(undefined);
+            }}
+          />
+        )}
+        {selectedPlugin === eventFilter && (
+          <EventFilterForm
+            formId={formId}
+            defaultConfig={getEventFilterConfigAtIndex(fields, editIndex)}
             onSubmit={(configuration) => {
               setDialogOpen(false);
               if (editIndex === undefined) {

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Outbound/index.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Outbound/index.tsx
@@ -11,6 +11,10 @@ import {
 } from "~/design/Select";
 import { Table, TableBody, TableCell, TableRow } from "~/design/Table";
 import { UseFormReturn, useFieldArray } from "react-hook-form";
+import {
+  availablePlugins,
+  outboundPluginTypes,
+} from "../../../schema/plugins/outbound";
 
 import Button from "~/design/Button";
 import { Card } from "~/design/Card";
@@ -19,7 +23,6 @@ import { JsOutboundForm } from "./JsOutboundForm";
 import { OutboundPluginFormSchemaType } from "../../../schema/plugins/outbound/schema";
 import { Plus } from "lucide-react";
 import { getJsOutboundConfigAtIndex } from "../utils";
-import { outboundPluginTypes } from "../../../schema/plugins/outbound";
 import { useTranslation } from "react-i18next";
 
 type OutboundPluginFormProps = {
@@ -154,7 +157,7 @@ export const OutboundPluginForm: FC<OutboundPluginFormProps> = ({ form }) => {
               />
             </SelectTrigger>
             <SelectContent>
-              {Object.values(outboundPluginTypes).map((pluginType) => (
+              {availablePlugins.map((pluginType) => (
                 <SelectItem key={pluginType} value={pluginType}>
                   {t(
                     `pages.explorer.endpoint.editor.form.plugins.outbound.types.${pluginType}`

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Outbound/index.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Outbound/index.tsx
@@ -157,17 +157,17 @@ export const OutboundPluginForm: FC<OutboundPluginFormProps> = ({ form }) => {
               />
             </SelectTrigger>
             <SelectContent>
-              {availablePlugins.map((pluginType) => (
-                <SelectItem key={pluginType} value={pluginType}>
+              {availablePlugins.map(({ name: pluginName }) => (
+                <SelectItem key={pluginName} value={pluginName}>
                   {t(
-                    `pages.explorer.endpoint.editor.form.plugins.outbound.types.${pluginType}`
+                    `pages.explorer.endpoint.editor.form.plugins.outbound.types.${pluginName}`
                   )}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
         </PluginSelector>
-        {selectedPlugin === outboundPluginTypes.jsOutbound && (
+        {selectedPlugin === outboundPluginTypes.jsOutbound.name && (
           <JsOutboundForm
             formId={formId}
             defaultConfig={getJsOutboundConfigAtIndex(fields, editIndex)}

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/InstantResponseForm.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/InstantResponseForm.tsx
@@ -18,7 +18,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 type OptionalConfig = Partial<InstantResponseFormSchemaType["configuration"]>;
 
-const predfinedConfig: OptionalConfig = {
+const predefinedConfig: OptionalConfig = {
   status_code: 200,
 };
 
@@ -44,7 +44,7 @@ export const InstantResponseForm: FC<FormProps> = ({
     defaultValues: {
       type: "instant-response",
       configuration: {
-        ...predfinedConfig,
+        ...predefinedConfig,
         ...defaultConfig,
       },
     },

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/TargetEventForm.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/TargetEventForm.tsx
@@ -1,0 +1,78 @@
+import { Controller, useForm } from "react-hook-form";
+import { FC, FormEvent } from "react";
+import FormErrors, { errorsType } from "~/componentsNext/FormErrors";
+import {
+  TargetEventFormSchema,
+  TargetEventFormSchemaType,
+} from "../../../schema/plugins/target/targetEvent";
+
+import { Fieldset } from "~/pages/namespace/Explorer/components/Fieldset";
+import NamespaceSelector from "~/componentsNext/NamespaceSelector";
+import { PluginWrapper } from "../components/Modal";
+import { useTranslation } from "react-i18next";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+type OptionalConfig = Partial<TargetEventFormSchemaType["configuration"]>;
+
+type FormProps = {
+  formId: string;
+  defaultConfig?: OptionalConfig;
+  onSubmit: (data: TargetEventFormSchemaType) => void;
+};
+
+export const TargetEventForm: FC<FormProps> = ({
+  defaultConfig,
+  onSubmit,
+  formId,
+}) => {
+  const { t } = useTranslation();
+  const {
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = useForm<TargetEventFormSchemaType>({
+    resolver: zodResolver(TargetEventFormSchema),
+    defaultValues: {
+      type: "target-event",
+      configuration: {
+        ...defaultConfig,
+      },
+    },
+  });
+
+  const submitForm = (e: FormEvent<HTMLFormElement>) => {
+    e.stopPropagation(); // prevent the parent form from submitting
+    handleSubmit(onSubmit)(e);
+  };
+
+  return (
+    <form onSubmit={submitForm} id={formId}>
+      <PluginWrapper>
+        {errors?.configuration && (
+          <FormErrors
+            errors={errors?.configuration as errorsType}
+            className="mb-5"
+          />
+        )}
+        <Fieldset
+          label={t(
+            "pages.explorer.endpoint.editor.form.plugins.target.targetFlow.namespace"
+          )}
+          htmlFor="namespace"
+        >
+          <Controller
+            control={control}
+            name="configuration.namespace"
+            render={({ field }) => (
+              <NamespaceSelector
+                id="namespace"
+                defaultValue={field.value}
+                onValueChange={field.onChange}
+              />
+            )}
+          />
+        </Fieldset>
+      </PluginWrapper>
+    </form>
+  );
+};

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/TargetEventForm.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/TargetEventForm.tsx
@@ -56,7 +56,7 @@ export const TargetEventForm: FC<FormProps> = ({
         )}
         <Fieldset
           label={t(
-            "pages.explorer.endpoint.editor.form.plugins.target.targetFlow.namespace"
+            "pages.explorer.endpoint.editor.form.plugins.target.targetEvent.namespace"
           )}
           htmlFor="namespace"
         >

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/TargetFlowForm.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/TargetFlowForm.tsx
@@ -18,7 +18,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 type OptionalConfig = Partial<TargetFlowFormSchemaType["configuration"]>;
 
-const predfinedConfig: OptionalConfig = {
+const predefinedConfig: OptionalConfig = {
   async: false,
 };
 
@@ -47,7 +47,7 @@ export const TargetFlowForm: FC<FormProps> = ({
     defaultValues: {
       type: "target-flow",
       configuration: {
-        ...predfinedConfig,
+        ...predefinedConfig,
         ...defaultConfig,
       },
     },

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
@@ -10,6 +10,10 @@ import {
 } from "~/design/Select";
 import { Table, TableBody, TableCell, TableRow } from "~/design/Table";
 import { UseFormReturn, useWatch } from "react-hook-form";
+import {
+  availablePlugins,
+  targetPluginTypes,
+} from "../../../schema/plugins/target";
 
 import Button from "~/design/Button";
 import { Card } from "~/design/Card";
@@ -22,7 +26,6 @@ import { TargetFlowForm } from "./TargetFlowForm";
 import { TargetFlowVarForm } from "./TargetFlowVarForm";
 import { TargetNamespaceFileForm } from "./TargetNamespaceFileForm";
 import { TargetNamespaceVarForm } from "./TargetNamespaceVarForm";
-import { targetPluginTypes } from "../../../schema/plugins/target";
 import { useTranslation } from "react-i18next";
 
 type TargetPluginFormProps = {
@@ -145,7 +148,7 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({ form }) => {
               />
             </SelectTrigger>
             <SelectContent>
-              {Object.values(targetPluginTypes).map((pluginType) => (
+              {availablePlugins.map((pluginType) => (
                 <SelectItem key={pluginType} value={pluginType}>
                   {t(
                     `pages.explorer.endpoint.editor.form.plugins.target.types.${pluginType}`

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
@@ -47,25 +47,37 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({ form }) => {
     targetEvent,
   } = targetPluginTypes;
 
-  const currentConfiguration = values.plugins?.target?.configuration;
+  const currentConfiguration = values.plugins?.target;
 
   const currentInstantResponseConfig =
-    currentType === instantResponse ? currentConfiguration : undefined;
+    currentConfiguration?.type === instantResponse
+      ? currentConfiguration.configuration
+      : undefined;
 
   const currentTargetEventConfig =
-    currentType === targetEvent ? currentConfiguration : undefined;
+    currentConfiguration?.type === targetEvent
+      ? currentConfiguration.configuration
+      : undefined;
 
   const currentTargetFlowConfig =
-    currentType === targetFlow ? currentConfiguration : undefined;
+    currentConfiguration?.type === targetFlow
+      ? currentConfiguration.configuration
+      : undefined;
 
   const currentTargetFlowVarConfig =
-    currentType === targetFlowVar ? currentConfiguration : undefined;
+    currentConfiguration?.type === targetFlowVar
+      ? currentConfiguration.configuration
+      : undefined;
 
   const currentTargetNamespaceFileConfig =
-    currentType === targetNamespaceFile ? currentConfiguration : undefined;
+    currentConfiguration?.type === targetNamespaceFile
+      ? currentConfiguration.configuration
+      : undefined;
 
   const currentTargetNamespaceVarConfig =
-    currentType === targetNamespaceVar ? currentConfiguration : undefined;
+    currentConfiguration?.type === targetNamespaceVar
+      ? currentConfiguration.configuration
+      : undefined;
 
   const formId = "targetPluginForm";
 

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
@@ -53,32 +53,32 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({ form }) => {
   const currentConfiguration = values.plugins?.target;
 
   const currentInstantResponseConfig =
-    currentConfiguration?.type === instantResponse
+    currentConfiguration?.type === instantResponse.name
       ? currentConfiguration.configuration
       : undefined;
 
   const currentTargetEventConfig =
-    currentConfiguration?.type === targetEvent
+    currentConfiguration?.type === targetEvent.name
       ? currentConfiguration.configuration
       : undefined;
 
   const currentTargetFlowConfig =
-    currentConfiguration?.type === targetFlow
+    currentConfiguration?.type === targetFlow.name
       ? currentConfiguration.configuration
       : undefined;
 
   const currentTargetFlowVarConfig =
-    currentConfiguration?.type === targetFlowVar
+    currentConfiguration?.type === targetFlowVar.name
       ? currentConfiguration.configuration
       : undefined;
 
   const currentTargetNamespaceFileConfig =
-    currentConfiguration?.type === targetNamespaceFile
+    currentConfiguration?.type === targetNamespaceFile.name
       ? currentConfiguration.configuration
       : undefined;
 
   const currentTargetNamespaceVarConfig =
-    currentConfiguration?.type === targetNamespaceVar
+    currentConfiguration?.type === targetNamespaceVar.name
       ? currentConfiguration.configuration
       : undefined;
 
@@ -148,10 +148,10 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({ form }) => {
               />
             </SelectTrigger>
             <SelectContent>
-              {availablePlugins.map((pluginType) => (
-                <SelectItem key={pluginType} value={pluginType}>
+              {availablePlugins.map(({ name: pluginName }) => (
+                <SelectItem key={pluginName} value={pluginName}>
                   {t(
-                    `pages.explorer.endpoint.editor.form.plugins.target.types.${pluginType}`
+                    `pages.explorer.endpoint.editor.form.plugins.target.types.${pluginName}`
                   )}
                 </SelectItem>
               ))}
@@ -159,7 +159,7 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({ form }) => {
           </Select>
         </PluginSelector>
 
-        {selectedPlugin === instantResponse && (
+        {selectedPlugin === instantResponse.name && (
           <InstantResponseForm
             formId={formId}
             defaultConfig={currentInstantResponseConfig}
@@ -169,7 +169,7 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({ form }) => {
             }}
           />
         )}
-        {selectedPlugin === targetFlow && (
+        {selectedPlugin === targetFlow.name && (
           <TargetFlowForm
             formId={formId}
             defaultConfig={currentTargetFlowConfig}
@@ -179,7 +179,7 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({ form }) => {
             }}
           />
         )}
-        {selectedPlugin === targetFlowVar && (
+        {selectedPlugin === targetFlowVar.name && (
           <TargetFlowVarForm
             formId={formId}
             defaultConfig={currentTargetFlowVarConfig}
@@ -189,7 +189,7 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({ form }) => {
             }}
           />
         )}
-        {selectedPlugin === targetNamespaceFile && (
+        {selectedPlugin === targetNamespaceFile.name && (
           <TargetNamespaceFileForm
             formId={formId}
             defaultConfig={currentTargetNamespaceFileConfig}
@@ -199,7 +199,7 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({ form }) => {
             }}
           />
         )}
-        {selectedPlugin === targetNamespaceVar && (
+        {selectedPlugin === targetNamespaceVar.name && (
           <TargetNamespaceVarForm
             formId={formId}
             defaultConfig={currentTargetNamespaceVarConfig}
@@ -209,7 +209,7 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({ form }) => {
             }}
           />
         )}
-        {selectedPlugin === targetEvent && (
+        {selectedPlugin === targetEvent.name && (
           <TargetEventForm
             formId={formId}
             defaultConfig={currentTargetEventConfig}

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/Target/index.tsx
@@ -17,6 +17,7 @@ import { EndpointFormSchemaType } from "../../../schema";
 import { InstantResponseForm } from "./InstantResponseForm";
 import { Settings } from "lucide-react";
 import { TableHeader } from "../components/PluginsTable";
+import { TargetEventForm } from "./TargetEventForm";
 import { TargetFlowForm } from "./TargetFlowForm";
 import { TargetFlowVarForm } from "./TargetFlowVarForm";
 import { TargetNamespaceFileForm } from "./TargetNamespaceFileForm";
@@ -43,12 +44,16 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({ form }) => {
     targetFlowVar,
     targetNamespaceFile,
     targetNamespaceVar,
+    targetEvent,
   } = targetPluginTypes;
 
   const currentConfiguration = values.plugins?.target?.configuration;
 
   const currentInstantResponseConfig =
     currentType === instantResponse ? currentConfiguration : undefined;
+
+  const currentTargetEventConfig =
+    currentType === targetEvent ? currentConfiguration : undefined;
 
   const currentTargetFlowConfig =
     currentType === targetFlow ? currentConfiguration : undefined;
@@ -183,6 +188,16 @@ export const TargetPluginForm: FC<TargetPluginFormProps> = ({ form }) => {
           <TargetNamespaceVarForm
             formId={formId}
             defaultConfig={currentTargetNamespaceVarConfig}
+            onSubmit={(configuration) => {
+              setDialogOpen(false);
+              form.setValue("plugins.target", configuration);
+            }}
+          />
+        )}
+        {selectedPlugin === targetEvent && (
+          <TargetEventForm
+            formId={formId}
+            defaultConfig={currentTargetEventConfig}
             onSubmit={(configuration) => {
               setDialogOpen(false);
               form.setValue("plugins.target", configuration);

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/utils.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/utils.ts
@@ -1,6 +1,7 @@
 import { AclFormSchemaType } from "../../schema/plugins/inbound/acl";
 import { AuthPluginFormSchemaType } from "../../schema/plugins/auth/schema";
 import { BasicAuthFormSchemaType } from "../../schema/plugins/auth/basicAuth";
+import { EventFilterFormSchemaType } from "../../schema/plugins/inbound/eventFilter";
 import { GithubWebhookAuthFormSchemaType } from "../../schema/plugins/auth/githubWebhookAuth";
 import { InboundPluginFormSchemaType } from "../../schema/plugins/inbound/schema";
 import { JsInboundFormSchemaType } from "../../schema/plugins/inbound/jsInbound";
@@ -38,6 +39,16 @@ export const getAclConfigAtIndex = (
 ): AclFormSchemaType["configuration"] | undefined => {
   const plugin = index !== undefined ? fields?.[index] : undefined;
   return plugin?.type === inboundPluginTypes.acl
+    ? plugin.configuration
+    : undefined;
+};
+
+export const getEventFilterConfigAtIndex = (
+  fields: InboundPluginFormSchemaType[] | undefined,
+  index: number | undefined
+): EventFilterFormSchemaType["configuration"] | undefined => {
+  const plugin = index !== undefined ? fields?.[index] : undefined;
+  return plugin?.type === inboundPluginTypes.eventFilter
     ? plugin.configuration
     : undefined;
 };

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/utils.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/utils.ts
@@ -68,7 +68,7 @@ export const getBasicAuthConfigAtIndex = (
   index: number | undefined
 ): BasicAuthFormSchemaType["configuration"] | undefined => {
   const plugin = index !== undefined ? fields?.[index] : undefined;
-  return plugin?.type === authPluginTypes.basicAuth
+  return plugin?.type === authPluginTypes.basicAuth.name
     ? plugin.configuration
     : undefined;
 };
@@ -78,7 +78,7 @@ export const getKeyAuthConfigAtIndex = (
   index: number | undefined
 ): KeyAuthFormSchemaType["configuration"] | undefined => {
   const plugin = index !== undefined ? fields?.[index] : undefined;
-  return plugin?.type === authPluginTypes.keyAuth
+  return plugin?.type === authPluginTypes.keyAuth.name
     ? plugin.configuration
     : undefined;
 };
@@ -88,7 +88,7 @@ export const getGithubWebhookAuthConfigAtIndex = (
   index: number | undefined
 ): GithubWebhookAuthFormSchemaType["configuration"] | undefined => {
   const plugin = index !== undefined ? fields?.[index] : undefined;
-  return plugin?.type === authPluginTypes.githubWebhookAuth
+  return plugin?.type === authPluginTypes.githubWebhookAuth.name
     ? plugin.configuration
     : undefined;
 };

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/utils.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/utils.ts
@@ -18,7 +18,7 @@ export const getRequestConvertConfigAtIndex = (
   index: number | undefined
 ): RequestConvertFormSchemaType["configuration"] | undefined => {
   const plugin = index !== undefined ? fields?.[index] : undefined;
-  return plugin?.type === inboundPluginTypes.requestConvert
+  return plugin?.type === inboundPluginTypes.requestConvert.name
     ? plugin.configuration
     : undefined;
 };
@@ -28,7 +28,7 @@ export const getJsInboundConfigAtIndex = (
   index: number | undefined
 ): JsInboundFormSchemaType["configuration"] | undefined => {
   const plugin = index !== undefined ? fields?.[index] : undefined;
-  return plugin?.type === inboundPluginTypes.jsInbound
+  return plugin?.type === inboundPluginTypes.jsInbound.name
     ? plugin.configuration
     : undefined;
 };
@@ -38,7 +38,7 @@ export const getAclConfigAtIndex = (
   index: number | undefined
 ): AclFormSchemaType["configuration"] | undefined => {
   const plugin = index !== undefined ? fields?.[index] : undefined;
-  return plugin?.type === inboundPluginTypes.acl
+  return plugin?.type === inboundPluginTypes.acl.name
     ? plugin.configuration
     : undefined;
 };
@@ -48,7 +48,7 @@ export const getEventFilterConfigAtIndex = (
   index: number | undefined
 ): EventFilterFormSchemaType["configuration"] | undefined => {
   const plugin = index !== undefined ? fields?.[index] : undefined;
-  return plugin?.type === inboundPluginTypes.eventFilter
+  return plugin?.type === inboundPluginTypes.eventFilter.name
     ? plugin.configuration
     : undefined;
 };

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/utils.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/Form/plugins/utils.ts
@@ -58,7 +58,7 @@ export const getJsOutboundConfigAtIndex = (
   index: number | undefined
 ): JsOutboundFormSchemaType["configuration"] | undefined => {
   const plugin = index !== undefined ? fields?.[index] : undefined;
-  return plugin?.type === outboundPluginTypes.jsOutbound
+  return plugin?.type === outboundPluginTypes.jsOutbound.name
     ? plugin.configuration
     : undefined;
 };

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/auth/basicAuth.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/auth/basicAuth.ts
@@ -2,7 +2,7 @@ import { authPluginTypes } from ".";
 import { z } from "zod";
 
 export const BasicAuthFormSchema = z.object({
-  type: z.literal(authPluginTypes.basicAuth),
+  type: z.literal(authPluginTypes.basicAuth.name),
   configuration: z.object({
     add_username_header: z.boolean(),
     add_tags_header: z.boolean(),

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/auth/githubWebhookAuth.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/auth/githubWebhookAuth.ts
@@ -2,7 +2,7 @@ import { authPluginTypes } from ".";
 import { z } from "zod";
 
 export const GithubWebhookAuthFormSchema = z.object({
-  type: z.literal(authPluginTypes.githubWebhookAuth),
+  type: z.literal(authPluginTypes.githubWebhookAuth.name),
   configuration: z.object({
     secret: z.string().nonempty(),
   }),

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/auth/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/auth/index.ts
@@ -1,11 +1,11 @@
+import { filterAvailablePlugins } from "../utils";
+
 export const authPluginTypes = {
   basicAuth: { name: "basic-auth", enterpriseOnly: false },
   githubWebhookAuth: { name: "github-webhook-auth", enterpriseOnly: false },
   keyAuth: { name: "key-auth", enterpriseOnly: false },
 } as const;
 
-const isEnterprise = !!process.env.VITE?.VITE_IS_ENTERPRISE;
-
 export const availablePlugins = Object.values(authPluginTypes).filter(
-  (plugin) => (isEnterprise ? true : plugin.enterpriseOnly === false)
+  filterAvailablePlugins
 );

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/auth/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/auth/index.ts
@@ -3,3 +3,5 @@ export const authPluginTypes = {
   githubWebhookAuth: "github-webhook-auth",
   keyAuth: "key-auth",
 } as const;
+
+export const availablePlugins = Object.values(authPluginTypes);

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/auth/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/auth/index.ts
@@ -1,7 +1,11 @@
 export const authPluginTypes = {
-  basicAuth: "basic-auth",
-  githubWebhookAuth: "github-webhook-auth",
-  keyAuth: "key-auth",
+  basicAuth: { name: "basic-auth", enterpriseOnly: false },
+  githubWebhookAuth: { name: "github-webhook-auth", enterpriseOnly: false },
+  keyAuth: { name: "key-auth", enterpriseOnly: false },
 } as const;
 
-export const availablePlugins = Object.values(authPluginTypes);
+const isEnterprise = !!process.env.VITE?.VITE_IS_ENTERPRISE;
+
+export const availablePlugins = Object.values(authPluginTypes).filter(
+  (plugin) => (isEnterprise ? true : plugin.enterpriseOnly === false)
+);

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/auth/keyAuth.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/auth/keyAuth.ts
@@ -2,7 +2,7 @@ import { authPluginTypes } from ".";
 import { z } from "zod";
 
 export const KeyAuthFormSchema = z.object({
-  type: z.literal(authPluginTypes.keyAuth),
+  type: z.literal(authPluginTypes.keyAuth.name),
   configuration: z.object({
     add_username_header: z.boolean(),
     add_tags_header: z.boolean(),

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/acl.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/acl.ts
@@ -2,7 +2,7 @@ import { inboundPluginTypes } from ".";
 import { z } from "zod";
 
 export const AclFormSchema = z.object({
-  type: z.literal(inboundPluginTypes.acl),
+  type: z.literal(inboundPluginTypes.acl.name),
   configuration: z.object({
     allow_groups: z.array(z.string()).optional(),
     deny_groups: z.array(z.string()).optional(),

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/eventFilter.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/eventFilter.ts
@@ -1,0 +1,11 @@
+import { inboundPluginTypes } from ".";
+import { z } from "zod";
+
+export const EventFilterFormSchema = z.object({
+  type: z.literal(inboundPluginTypes.eventFilter),
+  configuration: z.object({
+    script: z.string(),
+  }),
+});
+
+export type EventFilterFormSchemaType = z.infer<typeof EventFilterFormSchema>;

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/eventFilter.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/eventFilter.ts
@@ -5,6 +5,7 @@ export const EventFilterFormSchema = z.object({
   type: z.literal(inboundPluginTypes.eventFilter),
   configuration: z.object({
     script: z.string(),
+    allow_non_events: z.boolean(),
   }),
 });
 

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/eventFilter.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/eventFilter.ts
@@ -2,7 +2,7 @@ import { inboundPluginTypes } from ".";
 import { z } from "zod";
 
 export const EventFilterFormSchema = z.object({
-  type: z.literal(inboundPluginTypes.eventFilter),
+  type: z.literal(inboundPluginTypes.eventFilter.name),
   configuration: z.object({
     script: z.string(),
     allow_non_events: z.boolean(),

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/index.ts
@@ -4,3 +4,15 @@ export const inboundPluginTypes = {
   requestConvert: "request-convert",
   eventFilter: "event-filter",
 } as const;
+
+const allPlugins = Object.values(inboundPluginTypes);
+const enterpriseOnlyPlugins = [inboundPluginTypes.eventFilter] as string[];
+
+const enterprisePlugins = allPlugins;
+const openSourcePlugins = allPlugins.filter(
+  (plugin) => !enterpriseOnlyPlugins.includes(plugin)
+);
+const isEnterprise = !!process.env.VITE?.VITE_IS_ENTERPRISE;
+export const availablePlugins = isEnterprise
+  ? enterprisePlugins
+  : openSourcePlugins;

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/index.ts
@@ -1,3 +1,5 @@
+import { filterAvailablePlugins } from "../utils";
+
 export const inboundPluginTypes = {
   acl: {
     name: "acl",
@@ -17,8 +19,6 @@ export const inboundPluginTypes = {
   },
 } as const;
 
-const isEnterprise = !!process.env.VITE?.VITE_IS_ENTERPRISE;
-
 export const availablePlugins = Object.values(inboundPluginTypes).filter(
-  (plugin) => (isEnterprise ? true : plugin.enterpriseOnly === false)
+  filterAvailablePlugins
 );

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/index.ts
@@ -1,18 +1,24 @@
 export const inboundPluginTypes = {
-  acl: "acl",
-  jsInbound: "js-inbound",
-  requestConvert: "request-convert",
-  eventFilter: "event-filter",
+  acl: {
+    name: "acl",
+    enterpriseOnly: false,
+  },
+  jsInbound: {
+    name: "js-inbound",
+    enterpriseOnly: false,
+  },
+  requestConvert: {
+    name: "request-convert",
+    enterpriseOnly: false,
+  },
+  eventFilter: {
+    name: "event-filter",
+    enterpriseOnly: true,
+  },
 } as const;
 
-const allPlugins = Object.values(inboundPluginTypes);
-const enterpriseOnlyPlugins = [inboundPluginTypes.eventFilter] as string[];
-
-const enterprisePlugins = allPlugins;
-const openSourcePlugins = allPlugins.filter(
-  (plugin) => !enterpriseOnlyPlugins.includes(plugin)
-);
 const isEnterprise = !!process.env.VITE?.VITE_IS_ENTERPRISE;
-export const availablePlugins = isEnterprise
-  ? enterprisePlugins
-  : openSourcePlugins;
+
+export const availablePlugins = Object.values(inboundPluginTypes).filter(
+  (plugin) => (isEnterprise ? true : plugin.enterpriseOnly === false)
+);

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/index.ts
@@ -2,4 +2,5 @@ export const inboundPluginTypes = {
   acl: "acl",
   jsInbound: "js-inbound",
   requestConvert: "request-convert",
+  eventFilter: "event-filter",
 } as const;

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/jsInbound.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/jsInbound.ts
@@ -2,7 +2,7 @@ import { inboundPluginTypes } from ".";
 import { z } from "zod";
 
 export const JsInboundFormSchema = z.object({
-  type: z.literal(inboundPluginTypes.jsInbound),
+  type: z.literal(inboundPluginTypes.jsInbound.name),
   configuration: z.object({
     script: z.string(),
   }),

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/requestConvert.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/requestConvert.ts
@@ -2,7 +2,7 @@ import { inboundPluginTypes } from ".";
 import { z } from "zod";
 
 export const RequestConvertFormSchema = z.object({
-  type: z.literal(inboundPluginTypes.requestConvert),
+  type: z.literal(inboundPluginTypes.requestConvert.name),
   configuration: z.object({
     omit_headers: z.boolean(),
     omit_queries: z.boolean(),

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/schema.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/inbound/schema.ts
@@ -1,4 +1,5 @@
 import { AclFormSchema } from "./acl";
+import { EventFilterFormSchema } from "./eventFilter";
 import { JsInboundFormSchema } from "./jsInbound";
 import { RequestConvertFormSchema } from "./requestConvert";
 import { z } from "zod";
@@ -7,6 +8,7 @@ export const InboundPluginFormSchema = z.discriminatedUnion("type", [
   AclFormSchema,
   JsInboundFormSchema,
   RequestConvertFormSchema,
+  EventFilterFormSchema,
 ]);
 
 export type InboundPluginFormSchemaType = z.infer<

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/outbound/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/outbound/index.ts
@@ -1,3 +1,5 @@
 export const outboundPluginTypes = {
   jsOutbound: "js-outbound",
 } as const;
+
+export const availablePlugins = Object.values(outboundPluginTypes);

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/outbound/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/outbound/index.ts
@@ -1,5 +1,9 @@
 export const outboundPluginTypes = {
-  jsOutbound: "js-outbound",
+  jsOutbound: { name: "js-outbound", enterpriseOnly: false },
 } as const;
 
-export const availablePlugins = Object.values(outboundPluginTypes);
+const isEnterprise = !!process.env.VITE?.VITE_IS_ENTERPRISE;
+
+export const availablePlugins = Object.values(outboundPluginTypes).filter(
+  (plugin) => (isEnterprise ? true : plugin.enterpriseOnly === false)
+);

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/outbound/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/outbound/index.ts
@@ -1,9 +1,9 @@
+import { filterAvailablePlugins } from "../utils";
+
 export const outboundPluginTypes = {
   jsOutbound: { name: "js-outbound", enterpriseOnly: false },
 } as const;
 
-const isEnterprise = !!process.env.VITE?.VITE_IS_ENTERPRISE;
-
 export const availablePlugins = Object.values(outboundPluginTypes).filter(
-  (plugin) => (isEnterprise ? true : plugin.enterpriseOnly === false)
+  filterAvailablePlugins
 );

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/outbound/jsOutbound.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/outbound/jsOutbound.ts
@@ -2,7 +2,7 @@ import { outboundPluginTypes } from ".";
 import { z } from "zod";
 
 export const JsOutboundFormSchema = z.object({
-  type: z.literal(outboundPluginTypes.jsOutbound),
+  type: z.literal(outboundPluginTypes.jsOutbound.name),
   configuration: z.object({
     script: z.string(),
   }),

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/index.ts
@@ -1,20 +1,32 @@
 export const targetPluginTypes = {
-  instantResponse: "instant-response",
-  targetFlow: "target-flow",
-  targetFlowVar: "target-flow-var",
-  targetNamespaceFile: "target-namespace-file",
-  targetNamespaceVar: "target-namespace-var",
-  targetEvent: "target-event",
+  instantResponse: {
+    name: "instant-response",
+    enterpriseOnly: false,
+  },
+  targetFlow: {
+    name: "target-flow",
+    enterpriseOnly: false,
+  },
+  targetFlowVar: {
+    name: "target-flow-var",
+    enterpriseOnly: false,
+  },
+  targetNamespaceFile: {
+    name: "target-namespace-file",
+    enterpriseOnly: false,
+  },
+  targetNamespaceVar: {
+    name: "target-namespace-var",
+    enterpriseOnly: false,
+  },
+  targetEvent: {
+    name: "target-event",
+    enterpriseOnly: true,
+  },
 } as const;
 
-const allPlugins = Object.values(targetPluginTypes);
-const enterpriseOnlyPlugins = [targetPluginTypes.targetEvent] as string[];
-
-const enterprisePlugins = allPlugins;
-const openSourcePlugins = allPlugins.filter(
-  (plugin) => !enterpriseOnlyPlugins.includes(plugin)
-);
 const isEnterprise = !!process.env.VITE?.VITE_IS_ENTERPRISE;
-export const availablePlugins = isEnterprise
-  ? enterprisePlugins
-  : openSourcePlugins;
+
+export const availablePlugins = Object.values(targetPluginTypes).filter(
+  (plugin) => (isEnterprise ? true : !plugin.enterpriseOnly)
+);

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/index.ts
@@ -6,3 +6,15 @@ export const targetPluginTypes = {
   targetNamespaceVar: "target-namespace-var",
   targetEvent: "target-event",
 } as const;
+
+const allPlugins = Object.values(targetPluginTypes);
+const enterpriseOnlyPlugins = [targetPluginTypes.targetEvent] as string[];
+
+const enterprisePlugins = allPlugins;
+const openSourcePlugins = allPlugins.filter(
+  (plugin) => !enterpriseOnlyPlugins.includes(plugin)
+);
+const isEnterprise = !!process.env.VITE?.VITE_IS_ENTERPRISE;
+export const availablePlugins = isEnterprise
+  ? enterprisePlugins
+  : openSourcePlugins;

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/index.ts
@@ -28,5 +28,5 @@ export const targetPluginTypes = {
 const isEnterprise = !!process.env.VITE?.VITE_IS_ENTERPRISE;
 
 export const availablePlugins = Object.values(targetPluginTypes).filter(
-  (plugin) => (isEnterprise ? true : !plugin.enterpriseOnly)
+  (plugin) => (isEnterprise ? true : plugin.enterpriseOnly === false)
 );

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/index.ts
@@ -1,3 +1,5 @@
+import { filterAvailablePlugins } from "../utils";
+
 export const targetPluginTypes = {
   instantResponse: {
     name: "instant-response",
@@ -25,8 +27,6 @@ export const targetPluginTypes = {
   },
 } as const;
 
-const isEnterprise = !!process.env.VITE?.VITE_IS_ENTERPRISE;
-
 export const availablePlugins = Object.values(targetPluginTypes).filter(
-  (plugin) => (isEnterprise ? true : plugin.enterpriseOnly === false)
+  filterAvailablePlugins
 );

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/index.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/index.ts
@@ -4,4 +4,5 @@ export const targetPluginTypes = {
   targetFlowVar: "target-flow-var",
   targetNamespaceFile: "target-namespace-file",
   targetNamespaceVar: "target-namespace-var",
+  targetEvent: "target-event",
 } as const;

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/instantResponse.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/instantResponse.ts
@@ -2,7 +2,7 @@ import { targetPluginTypes } from ".";
 import { z } from "zod";
 
 export const InstantResponseFormSchema = z.object({
-  type: z.literal(targetPluginTypes.instantResponse),
+  type: z.literal(targetPluginTypes.instantResponse.name),
   configuration: z.object({
     content_type: z.string().optional(),
     status_code: z.number().int().positive(),

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/schema.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/schema.ts
@@ -1,4 +1,5 @@
 import { InstantResponseFormSchema } from "./instantResponse";
+import { TargetEventFormSchema } from "./targetEvent";
 import { TargetFlowFormSchema } from "./targetFlow";
 import { TargetFlowVarFormSchema } from "./targetFlowVar";
 import { TargetNamespaceFileFormSchema } from "./targetNamespaceFile";
@@ -11,4 +12,5 @@ export const TargetPluginFormSchema = z.discriminatedUnion("type", [
   TargetFlowVarFormSchema,
   TargetNamespaceFileFormSchema,
   TargetNamespaceVarFormSchema,
+  TargetEventFormSchema,
 ]);

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/targetEvent.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/targetEvent.ts
@@ -1,0 +1,11 @@
+import { targetPluginTypes } from ".";
+import { z } from "zod";
+
+export const TargetEventFormSchema = z.object({
+  type: z.literal(targetPluginTypes.targetEvent),
+  configuration: z.object({
+    namespace: z.string().optional(),
+  }),
+});
+
+export type TargetEventFormSchemaType = z.infer<typeof TargetEventFormSchema>;

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/targetEvent.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/targetEvent.ts
@@ -2,7 +2,7 @@ import { targetPluginTypes } from ".";
 import { z } from "zod";
 
 export const TargetEventFormSchema = z.object({
-  type: z.literal(targetPluginTypes.targetEvent),
+  type: z.literal(targetPluginTypes.targetEvent.name),
   configuration: z
     .object({
       namespace: z.string().optional(),

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/targetEvent.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/targetEvent.ts
@@ -3,9 +3,11 @@ import { z } from "zod";
 
 export const TargetEventFormSchema = z.object({
   type: z.literal(targetPluginTypes.targetEvent),
-  configuration: z.object({
-    namespace: z.string().optional(),
-  }),
+  configuration: z
+    .object({
+      namespace: z.string().optional(),
+    })
+    .nullable(), // since all fields are optional, we need to make the whole object optional
 });
 
 export type TargetEventFormSchemaType = z.infer<typeof TargetEventFormSchema>;

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/targetFlow.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/targetFlow.ts
@@ -2,7 +2,7 @@ import { targetPluginTypes } from ".";
 import { z } from "zod";
 
 export const TargetFlowFormSchema = z.object({
-  type: z.literal(targetPluginTypes.targetFlow),
+  type: z.literal(targetPluginTypes.targetFlow.name),
   configuration: z.object({
     namespace: z.string().optional(),
     flow: z.string().nonempty(),

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/targetFlowVar.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/targetFlowVar.ts
@@ -2,7 +2,7 @@ import { targetPluginTypes } from ".";
 import { z } from "zod";
 
 export const TargetFlowVarFormSchema = z.object({
-  type: z.literal(targetPluginTypes.targetFlowVar),
+  type: z.literal(targetPluginTypes.targetFlowVar.name),
   configuration: z.object({
     namespace: z.string().optional(),
     flow: z.string().nonempty(),

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/targetNamespaceFile.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/targetNamespaceFile.ts
@@ -2,7 +2,7 @@ import { targetPluginTypes } from ".";
 import { z } from "zod";
 
 export const TargetNamespaceFileFormSchema = z.object({
-  type: z.literal(targetPluginTypes.targetNamespaceFile),
+  type: z.literal(targetPluginTypes.targetNamespaceFile.name),
   configuration: z.object({
     namespace: z.string().optional(),
     file: z.string().nonempty(),

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/targetNamespaceVar.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/target/targetNamespaceVar.ts
@@ -2,7 +2,7 @@ import { targetPluginTypes } from ".";
 import { z } from "zod";
 
 export const TargetNamespaceVarFormSchema = z.object({
-  type: z.literal(targetPluginTypes.targetNamespaceVar),
+  type: z.literal(targetPluginTypes.targetNamespaceVar.name),
   configuration: z.object({
     namespace: z.string().nonempty().optional(),
     variable: z.string().nonempty(),

--- a/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/utils.ts
+++ b/src/pages/namespace/Explorer/Endpoint/EndpointEditor/schema/plugins/utils.ts
@@ -1,0 +1,5 @@
+const isEnterprise = !!process.env.VITE?.VITE_IS_ENTERPRISE;
+type Plugin = { name: string; enterpriseOnly?: boolean };
+
+export const filterAvailablePlugins = (plugin: Plugin) =>
+  isEnterprise ? true : plugin.enterpriseOnly === false;


### PR DESCRIPTION
- adds two new plugins that are only available in ee:
  - inbound plugin: event-filter 
  - target plugin: target-event
- It also fixes a problem where a type was not narrowed down correctly (the wrong type did not throw any TS errors until the new plugins were added in this PR)
- The session schema changed in EE and needed to be updated (this only showed a console error, but did not break anything)

It is based on the `stefankracht/dir-1027-make-403-redirect-to-logout-path` branch, as this is the newest gateway branch. For a better diff view, the same branch is set as the target. 