### PR TITLE
Fix e2e timing problems

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,5 +22,8 @@ VITE_IS_ENTERPRISE="FALSE" # true or TRUE will evaluate to true, everything else
 VITE_E2E_UI_HOST="http://localhost"
 VITE_E2E_UI_PORT="3333"
 
+# Enable parallel tests by setting this to "TRUE". Any other value will disable parallel tests.
+VITE_E2E_PARALLEL="FALSE"
+
 # enable react query dev tools (only for dev server, they will always be excluded in production builds)
 VITE_RQ_DEV_TOOLS="FALSE" # true or TRUE will evaluate to true, everything else will be false

--- a/e2e/errorPage.spec.ts
+++ b/e2e/errorPage.spec.ts
@@ -15,7 +15,7 @@ test.afterAll(async () => {
 test("the 404 error page shows, when the user opens a url that does not exist", async ({
   page,
 }) => {
-  await page.goto("/this/page/does/not/exist");
+  await page.goto("/this/page/does/not/exist", { waitUntil: "networkidle" });
   await expect(page.getByTestId("error-title")).toHaveText("404");
   await expect(page.getByTestId("error-message")).toHaveText("Not Found");
 });

--- a/e2e/explorer/index.spec.ts
+++ b/e2e/explorer/index.spec.ts
@@ -26,7 +26,7 @@ test("it is possible to navigate to a namespace via breadcrumbs", async ({
   page,
 }) => {
   // visit page
-  await page.goto("/");
+  await page.goto("/", { waitUntil: "networkidle" });
 
   await expect(
     page.getByTestId("breadcrumb-namespace"),

--- a/e2e/settings/deleteNamespace.spec.ts
+++ b/e2e/settings/deleteNamespace.spec.ts
@@ -101,16 +101,11 @@ test("it is possible to delete the last namespace and it will redirect to the la
   const confirmButton = page.getByTestId("delete-namespace-confirm-btn");
   const confirmInput = page.getByTestId("delete-namespace-confirm-input");
 
-  confirmInput.type(namespace);
-  await confirmButton.click();
-
   /**
-   * when the api is now called for the namespaces, we return
+   * the next time the api is called for the namespaces, we return
    * an empty  list to act like there are no namespaces left
    */
-  const mockedNamespace: NamespaceListSchemaType = {
-    results: [],
-  };
+
   await page.route("**/api/namespaces", (route, reg) => {
     if (reg.method() !== "GET") {
       return route.continue();
@@ -118,9 +113,12 @@ test("it is possible to delete the last namespace and it will redirect to the la
     route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify(mockedNamespace),
+      body: JSON.stringify({ results: [] }),
     });
   });
+
+  confirmInput.type(namespace);
+  await confirmButton.click();
 
   await page.waitForURL("/");
   /**

--- a/e2e/settings/deleteNamespace.spec.ts
+++ b/e2e/settings/deleteNamespace.spec.ts
@@ -1,7 +1,6 @@
 import { createNamespace, deleteNamespace } from "../utils/namespace";
 import { expect, test } from "@playwright/test";
 
-import { NamespaceListSchemaType } from "~/api/namespaces/schema";
 import { getNamespaces } from "~/api/namespaces/query/get";
 import { headers } from "e2e/utils/testutils";
 

--- a/e2e/settings/deleteNamespace.spec.ts
+++ b/e2e/settings/deleteNamespace.spec.ts
@@ -1,6 +1,7 @@
 import { createNamespace, deleteNamespace } from "../utils/namespace";
 import { expect, test } from "@playwright/test";
 
+import { NamespaceListSchemaType } from "~/api/namespaces/schema";
 import { getNamespaces } from "~/api/namespaces/query/get";
 import { headers } from "e2e/utils/testutils";
 
@@ -105,6 +106,10 @@ test("it is possible to delete the last namespace and it will redirect to the la
    * an empty  list to act like there are no namespaces left
    */
 
+  const mockedNamespaces: NamespaceListSchemaType = {
+    results: [],
+  };
+
   await page.route("**/api/namespaces", (route, reg) => {
     if (reg.method() !== "GET") {
       return route.continue();
@@ -112,7 +117,7 @@ test("it is possible to delete the last namespace and it will redirect to the la
     route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ results: [] }),
+      body: JSON.stringify(mockedNamespaces),
     });
   });
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,8 +20,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Opt out of parallel tests. */
+  workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -36,6 +36,7 @@ export default defineConfig({
   },
 
   timeout: 30000, // defaults to 30000
+  expect: { timeout: 10000 },
 
   /* Configure projects for major browsers */
   projects: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,8 +20,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests. */
-  workers: 1,
+  /* Opt out of parallel tests per default. Enable parallel tests by setting
+     VITE_E2E_PARALLEL to TRUE. */
+  workers: process.env.VITE_E2E_PARALLEL === "TRUE" ? undefined : 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -76,6 +76,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
+    timeout: 60000,
     command: `yarn run vite --port ${process.env.VITE_E2E_UI_PORT}`,
     url: baseURL,
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
I had several problems with the e2e tests on my laptop. This fixes them (only the diagramEditor tests are still a bit flaky, but I can live with that for now).

As discussed in person, it is probably best to consider my new config values as "safe" and use them as our new default.

It is always a bit hard to be sure with playwright, but I think the main issues were:
- Multiple test runners in parallel were causing lots of timeouts, so I restricted "runners" to 1 in the config.
  - the original behavior can be restored by setting an ENV variable
- Playwright's built in test server needs a timeout to work reliably. I cannot make sense of the value itself (I just set it to the documented default), I only know that there are problems without setting this value here.
- I also set the timeout for expectations to 10s (from default 5s) which helps with a few tests
- I introduced some "waitFor: 'networkidle'" statements.
- Fixed one race condition where I suspect mock data wasn't ready before the request was triggered.