### PR TITLE
Fix e2e test for usermenu

### DIFF
--- a/e2e/usermenu.spec.ts
+++ b/e2e/usermenu.spec.ts
@@ -1,6 +1,18 @@
+import { createNamespace, deleteNamespace } from "./utils/namespace";
 import { expect, test } from "@playwright/test";
 
 import { getStyle } from "./utils/testutils";
+
+let namespace = "";
+
+test.beforeAll(async () => {
+  namespace = await createNamespace();
+});
+
+test.afterAll(async () => {
+  await deleteNamespace(namespace);
+  namespace = "";
+});
 
 test("it is possible to switch between light and dark mode", async ({
   page,


### PR DESCRIPTION
This fixes the e2e test for the user menu.

It failed on my system and when investigating, I found that no namespace is created before performing this test. So if performed in isolation, the onboarding page will be rendered and the user menu will not be accessible. Probably the test didn't fail in the past because namespaces from other tests existed.